### PR TITLE
omit empty properties to avoid issue with number inputs

### DIFF
--- a/pkg/study/types/survey-item.go
+++ b/pkg/study/types/survey-item.go
@@ -58,8 +58,8 @@ type Style struct {
 }
 
 type ComponentProperties struct {
-	Min           *ExpressionArg `bson:"min" json:"min"`
-	Max           *ExpressionArg `bson:"max" json:"max"`
-	StepSize      *ExpressionArg `bson:"stepSize" json:"stepSize"`
-	DateInputMode *ExpressionArg `bson:"dateInputMode" json:"dateInputMode"`
+	Min           *ExpressionArg `bson:"min,omitempty" json:"min,omitempty"`
+	Max           *ExpressionArg `bson:"max,omitempty" json:"max,omitempty"`
+	StepSize      *ExpressionArg `bson:"stepSize,omitempty" json:"stepSize,omitempty"`
+	DateInputMode *ExpressionArg `bson:"dateInputMode,omitempty" json:"dateInputMode,omitempty"`
 }


### PR DESCRIPTION
Number input response could not be set, because "null" values were sent out, and that caused front-end checks to fail if input's min and max are undefined