### PR TITLE
Extra ctx col names for exporter

### DIFF
--- a/pkg/apihelpers/parsePaginatedQuery.go
+++ b/pkg/apihelpers/parsePaginatedQuery.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"strconv"
+	"strings"
 
 	surveyresponses "github.com/case-framework/case-backend/pkg/study/exporter/survey-responses"
 	"github.com/gin-gonic/gin"
@@ -88,6 +89,7 @@ type ResponseExportQuery struct {
 	Format            string
 	IncludeMeta       *surveyresponses.IncludeMeta
 	PaginationInfos   *PagenatedQuery
+	ExtraCtxCols      *[]string
 }
 
 func ParseResponseExportQueryFromCtx(c *gin.Context) (*ResponseExportQuery, error) {
@@ -105,16 +107,22 @@ func ParseResponseExportQueryFromCtx(c *gin.Context) (*ResponseExportQuery, erro
 	questionOptionSep := c.DefaultQuery("questionOptionSep", "-")
 
 	format := c.DefaultQuery("format", "wide")
-
-	includeMeta := &surveyresponses.IncludeMeta{}
-	// TODO
-
-	return &ResponseExportQuery{
+	q := &ResponseExportQuery{
 		SurveyKey:         surveyKey,
 		UseShortKeys:      useShortKeys,
 		QuestionOptionSep: questionOptionSep,
 		Format:            format,
-		IncludeMeta:       includeMeta,
 		PaginationInfos:   paginatedQuery,
-	}, nil
+	}
+
+	extraCtxColsQuery := c.DefaultQuery("extraContextColumns", "")
+	if extraCtxColsQuery != "" {
+		*q.ExtraCtxCols = strings.Split(extraCtxColsQuery, ",")
+	}
+
+	// TODO
+	includeMeta := &surveyresponses.IncludeMeta{}
+	q.IncludeMeta = includeMeta
+
+	return q, nil
 }

--- a/pkg/study/exporter/survey-responses/parser.go
+++ b/pkg/study/exporter/survey-responses/parser.go
@@ -9,6 +9,14 @@ import (
 	studytypes "github.com/case-framework/case-backend/pkg/study/types"
 )
 
+var (
+	defaultCtxColNames = []string{
+		"language",
+		"engineVersion",
+		"session",
+	}
+)
+
 type ResponseParser struct {
 	surveyVersions    []studydefinition.SurveyVersionPreview
 	surveyKey         string
@@ -24,6 +32,7 @@ func NewResponseParser(
 	removeRootKey bool,
 	includeMeta *IncludeMeta,
 	questionOptionSep string,
+	extraContextColumns *[]string,
 ) (*ResponseParser, error) {
 	rp := &ResponseParser{
 		surveyKey:         surveyKey,
@@ -33,14 +42,14 @@ func NewResponseParser(
 		questionOptionSep: questionOptionSep,
 	}
 
-	if err := rp.initColumnNames(); err != nil {
+	if err := rp.initColumnNames(extraContextColumns); err != nil {
 		return nil, err
 	}
 
 	return rp, nil
 }
 
-func (rp *ResponseParser) initColumnNames() error {
+func (rp *ResponseParser) initColumnNames(extraContextColumns *[]string) error {
 	fixedCols := []string{
 		"ID",
 		"participantID",
@@ -49,10 +58,9 @@ func (rp *ResponseParser) initColumnNames() error {
 		"submitted",
 	}
 
-	ctxCols := []string{
-		"language",
-		"engineVersion",
-		"session",
+	ctxCols := defaultCtxColNames
+	if extraContextColumns != nil {
+		ctxCols = append(ctxCols, *extraContextColumns...)
 	}
 
 	if rp.removeRootKey {

--- a/pkg/study/exporter/survey-responses/utils.go
+++ b/pkg/study/exporter/survey-responses/utils.go
@@ -25,6 +25,18 @@ func valueToStr(resultVal interface{}) string {
 		str = fmt.Sprintf("%d", colValue)
 	case float64:
 		str = fmt.Sprintf("%f", colValue)
+	case []int64:
+		strLst := []string{}
+		for _, v := range colValue {
+			strLst = append(strLst, fmt.Sprintf("%d", v))
+		}
+		str = strings.Join(strLst, ",")
+	case []int32:
+		strLst := []string{}
+		for _, v := range colValue {
+			strLst = append(strLst, fmt.Sprintf("%d", v))
+		}
+		str = strings.Join(strLst, ",")
 	case *studytypes.ResponseItem:
 		jsonBytes, err := json.Marshal(colValue)
 		if err != nil {

--- a/pkg/study/exporter/survey-responses/utils.go
+++ b/pkg/study/exporter/survey-responses/utils.go
@@ -21,6 +21,8 @@ func valueToStr(resultVal interface{}) string {
 		str = colValue
 	case int:
 		str = fmt.Sprintf("%d", colValue)
+	case int32:
+		str = fmt.Sprintf("%d", colValue)
 	case int64:
 		str = fmt.Sprintf("%d", colValue)
 	case float64:

--- a/pkg/study/participant-data.go
+++ b/pkg/study/participant-data.go
@@ -86,7 +86,7 @@ func GetAssignedSurveys(instanceID string, studyKey string, profileIDs []string)
 		if !found {
 			surveyDef, err := studyDBService.GetCurrentSurveyVersion(instanceID, studyKey, survey.SurveyKey)
 			if err != nil {
-				slog.Error("error getting survey definition", slog.String("error", err.Error()))
+				slog.Error("error getting survey definition", slog.String("error", err.Error()), slog.String("surveyKey", survey.SurveyKey))
 				continue
 			}
 			surveyInfo := SurveyInfo{

--- a/services/management-api/apihandlers/study-management.go
+++ b/services/management-api/apihandlers/study-management.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gin-gonic/gin"
 
 	studyDB "github.com/case-framework/case-backend/pkg/db/study"
-	studydefinition "github.com/case-framework/case-backend/pkg/study/exporter/survey-definition"
 	surveydefinition "github.com/case-framework/case-backend/pkg/study/exporter/survey-definition"
 	surveyresponses "github.com/case-framework/case-backend/pkg/study/exporter/survey-responses"
 	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
@@ -1619,7 +1618,7 @@ func (h *HttpEndpoints) getSurveyInfo(c *gin.Context) {
 
 	slog.Info("getting survey info", slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject), slog.String("studyKey", studyKey), slog.String("surveyKey", surveyKey))
 
-	sInfos, err := studydefinition.PrepareSurveyInfosFromDB(
+	sInfos, err := surveydefinition.PrepareSurveyInfosFromDB(
 		h.studyDBConn,
 		token.InstanceID,
 		studyKey,
@@ -1634,7 +1633,7 @@ func (h *HttpEndpoints) getSurveyInfo(c *gin.Context) {
 		return
 	}
 
-	siExp := studydefinition.NewSurveyInfoExporter(
+	siExp := surveydefinition.NewSurveyInfoExporter(
 		sInfos,
 		surveyKey,
 		shortKeys,
@@ -1718,7 +1717,7 @@ func (h *HttpEndpoints) generateResponsesExport(c *gin.Context) {
 		return
 	}
 
-	surveyVersions, err := studydefinition.PrepareSurveyInfosFromDB(
+	surveyVersions, err := surveydefinition.PrepareSurveyInfosFromDB(
 		h.studyDBConn,
 		token.InstanceID,
 		studyKey,
@@ -1741,6 +1740,7 @@ func (h *HttpEndpoints) generateResponsesExport(c *gin.Context) {
 		query.UseShortKeys,
 		query.IncludeMeta,
 		query.QuestionOptionSep,
+		nil, // TODO: add extra context columns optionally
 	)
 	if err != nil {
 		slog.Error("failed to create response parser", slog.String("error", err.Error()))
@@ -2443,7 +2443,7 @@ func (h *HttpEndpoints) getStudyResponses(c *gin.Context) {
 		return
 	}
 
-	surveyVersions, err := studydefinition.PrepareSurveyInfosFromDB(
+	surveyVersions, err := surveydefinition.PrepareSurveyInfosFromDB(
 		h.studyDBConn,
 		token.InstanceID,
 		studyKey,
@@ -2466,6 +2466,7 @@ func (h *HttpEndpoints) getStudyResponses(c *gin.Context) {
 		query.UseShortKeys,
 		query.IncludeMeta,
 		query.QuestionOptionSep,
+		nil, // TODO: add extra context columns optionally
 	)
 	if err != nil {
 		slog.Error("failed to create response parser", slog.String("error", err.Error()))
@@ -2517,7 +2518,7 @@ func (h *HttpEndpoints) getStudyResponseById(c *gin.Context) {
 		return
 	}
 
-	surveyVersions, err := studydefinition.PrepareSurveyInfosFromDB(
+	surveyVersions, err := surveydefinition.PrepareSurveyInfosFromDB(
 		h.studyDBConn,
 		token.InstanceID,
 		studyKey,
@@ -2540,6 +2541,7 @@ func (h *HttpEndpoints) getStudyResponseById(c *gin.Context) {
 		query.UseShortKeys,
 		query.IncludeMeta,
 		query.QuestionOptionSep,
+		nil, // TODO: add extra context columns optionally
 	)
 	if err != nil {
 		slog.Error("failed to create response parser", slog.String("error", err.Error()))

--- a/services/management-api/apihandlers/study-management.go
+++ b/services/management-api/apihandlers/study-management.go
@@ -1740,7 +1740,7 @@ func (h *HttpEndpoints) generateResponsesExport(c *gin.Context) {
 		query.UseShortKeys,
 		query.IncludeMeta,
 		query.QuestionOptionSep,
-		nil, // TODO: add extra context columns optionally
+		query.ExtraCtxCols,
 	)
 	if err != nil {
 		slog.Error("failed to create response parser", slog.String("error", err.Error()))
@@ -2466,7 +2466,7 @@ func (h *HttpEndpoints) getStudyResponses(c *gin.Context) {
 		query.UseShortKeys,
 		query.IncludeMeta,
 		query.QuestionOptionSep,
-		nil, // TODO: add extra context columns optionally
+		query.ExtraCtxCols,
 	)
 	if err != nil {
 		slog.Error("failed to create response parser", slog.String("error", err.Error()))


### PR DESCRIPTION
Add the possibility for the response exporter to include extra context column names
Additionally, this PR fixes bugs for exporting metadata timestamps