### PR TITLE
Fix attempt sending emails to empty to list

### DIFF
--- a/jobs/messaging/scheduled-messages.go
+++ b/jobs/messaging/scheduled-messages.go
@@ -250,6 +250,11 @@ func prepOutgoingFromScheduledEmail(
 		payload["loginToken"] = token
 	}
 
+	if len(outgoingEmail.To) < 1 || len(outgoingEmail.To[0]) < 1 {
+		slog.Error("no recipients found", slog.String("instanceID", instanceID), slog.String("studyKey", message.StudyKey))
+		return nil, errors.New("no recipients found")
+	}
+
 	payload["studyKey"] = message.StudyKey
 
 	subject, content, err := emailsending.GenerateEmailContent(message.Template, user.Account.PreferredLanguage, payload)


### PR DESCRIPTION
In case somehow messages were generated with an empty `to` array, it caused them being stuck in the outgoing. This PR implements avoiding these cases, by preventing them to be added in first place, or removing them through the outgoing handler. 