### PR TITLE
Add expiration to outgoing emails

### DIFF
--- a/jobs/messaging/outgoing-messages.go
+++ b/jobs/messaging/outgoing-messages.go
@@ -15,6 +15,11 @@ func checkIfOutgoingEmailShouldBeSent(email messagingTypes.OutgoingEmail) bool {
 		return false
 	}
 
+	if email.ExpiresAt > 0 && email.ExpiresAt < time.Now().Unix() {
+		slog.Error("email expired", slog.String("messageType", email.MessageType))
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/messaging/email-sending/send.go
+++ b/pkg/messaging/email-sending/send.go
@@ -66,6 +66,7 @@ func SendInstantEmailByTemplate(
 	lang string,
 	payload map[string]string,
 	useLowPrio bool,
+	expiresAt int64,
 ) error {
 	if HttpClient == nil || HttpClient.RootURL == "" {
 		return errors.New("connection to smtp bridge not initialized")
@@ -84,6 +85,7 @@ func SendInstantEmailByTemplate(
 	if err != nil {
 		return err
 	}
+	outgoingEmail.ExpiresAt = expiresAt
 
 	// send email
 	err = SendOutgoingEmail(outgoingEmail)

--- a/pkg/messaging/types/outgoing_email.go
+++ b/pkg/messaging/types/outgoing_email.go
@@ -10,6 +10,7 @@ type OutgoingEmail struct {
 	HeaderOverrides *HeaderOverrides   `bson:"headerOverrides" json:"headerOverrides"`
 	Content         string             `bson:"content" json:"content"`
 	AddedAt         int64              `bson:"addedAt" json:"addedAt"`
+	ExpiresAt       int64              `bson:"expiresAt" json:"expiresAt"`
 	HighPrio        bool               `bson:"highPrio" json:"highPrio"`
 	LastSendAttempt int64              `bson:"lastSendAttempt" json:"lastSendAttempt"`
 }

--- a/pkg/user-management/user-management.go
+++ b/pkg/user-management/user-management.go
@@ -34,7 +34,7 @@ func Init(
 func SendOTPByEmail(
 	instanceID,
 	userID string,
-	sendEmail func(email string, code string, preferredLang string) error,
+	sendEmail func(email string, code string, preferredLang string, expiresAt int64) error,
 ) error {
 	// check count of recent attempts
 	count, err := pUserDBService.CountOTP(instanceID, userID)
@@ -76,7 +76,7 @@ func SendOTPByEmail(
 	formattedCode := fmt.Sprintf("%s-%s", code[:half], code[half:])
 
 	// send OTP
-	err = sendEmail(user.Account.AccountID, formattedCode, user.Account.PreferredLanguage)
+	err = sendEmail(user.Account.AccountID, formattedCode, user.Account.PreferredLanguage, time.Now().Add(time.Second*userDB.OTP_TTL).Unix())
 	if err != nil {
 		return err
 	}

--- a/services/participant-api/apihandlers/authentication.go
+++ b/services/participant-api/apihandlers/authentication.go
@@ -806,7 +806,7 @@ func (h *HttpEndpoints) requestOTP(c *gin.Context) {
 		err := usermanagement.SendOTPByEmail(
 			token.InstanceID,
 			token.Subject,
-			func(email string, code string, preferredLang string) error {
+			func(email string, code string, preferredLang string, expiresAt int64) error {
 				err := emailsending.SendInstantEmailByTemplate(
 					token.InstanceID,
 					[]string{email},
@@ -817,6 +817,7 @@ func (h *HttpEndpoints) requestOTP(c *gin.Context) {
 						"verificationCode": code,
 					},
 					false,
+					expiresAt,
 				)
 				if err != nil {
 					slog.Error("failed to send verification email", slog.String("error", err.Error()))

--- a/services/participant-api/apihandlers/utils.go
+++ b/services/participant-api/apihandlers/utils.go
@@ -52,6 +52,8 @@ func (h *HttpEndpoints) prepTokenAndSendEmail(
 	}
 	payload["token"] = tempToken
 
+	expiresAt := time.Now().Add(expiresIn).Unix()
+
 	err = emailsending.SendInstantEmailByTemplate(
 		instanceID,
 		[]string{email},
@@ -60,6 +62,7 @@ func (h *HttpEndpoints) prepTokenAndSendEmail(
 		lang,
 		payload,
 		false,
+		expiresAt,
 	)
 	if err != nil {
 		slog.Error("failed to send email", slog.String("error", err.Error()))
@@ -100,6 +103,7 @@ func (h *HttpEndpoints) sendSimpleEmail(
 		lang,
 		payload,
 		useLowPrio,
+		0, // does not expire
 	)
 	if err != nil {
 		slog.Error("failed to send email", slog.String("error", err.Error()))


### PR DESCRIPTION
In case the smtp-bridge was not available, or for any other reason, some emails were queued up in the outgoing collection, and then the email sending resumed, all stuck messages were sent out at once. Often this resulted in receiving multiple verification codes that were already expired at once in a batch.