### PR TITLE
Run study actions endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ storage
 serviceInfos.json
 test/jobs
 blocked_passwordlist.txt
+management-api.yaml

--- a/pkg/db/study/taskQueue.go
+++ b/pkg/db/study/taskQueue.go
@@ -56,6 +56,28 @@ func (dbService *StudyDBService) GetTaskByID(instanceID string, taskID string) (
 	return task, err
 }
 
+func (dbService *StudyDBService) UpdateTaskTotalCount(instanceID string, taskID string, totalCount int) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	_id, err := primitive.ObjectIDFromHex(taskID)
+	if err != nil {
+		return err
+	}
+
+	filter := bson.M{
+		"_id": _id,
+	}
+	update := bson.M{
+		"$set": bson.M{
+			"totalCount": totalCount,
+			"updatedAt":  time.Now(),
+		},
+	}
+	_, err = dbService.collectionTaskQueue(instanceID).UpdateOne(ctx, filter, update)
+	return err
+}
+
 // update task processed count
 func (dbService *StudyDBService) UpdateTaskProgress(instanceID string, taskID string, processedCount int) error {
 	ctx, cancel := dbService.getContext()

--- a/pkg/db/study/taskQueue.go
+++ b/pkg/db/study/taskQueue.go
@@ -70,8 +70,8 @@ func (dbService *StudyDBService) UpdateTaskTotalCount(instanceID string, taskID 
 	}
 	update := bson.M{
 		"$set": bson.M{
-			"totalCount": totalCount,
-			"updatedAt":  time.Now(),
+			"targetCount": totalCount,
+			"updatedAt":   time.Now(),
 		},
 	}
 	_, err = dbService.collectionTaskQueue(instanceID).UpdateOne(ctx, filter, update)

--- a/pkg/study/study-service.go
+++ b/pkg/study/study-service.go
@@ -463,6 +463,10 @@ type RunStudyActionResult struct {
 }
 
 func OnRunStudyAction(req RunStudyActionReq) (*RunStudyActionResult, error) {
+	if studyDBService == nil {
+		return nil, errors.New("studyDBService is not initialized")
+	}
+
 	if req.InstanceID == "" || req.StudyKey == "" {
 		return nil, errors.New("instanceID and studyKey are required")
 	}

--- a/pkg/study/study-service.go
+++ b/pkg/study/study-service.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"reflect"
 	"time"
 
 	studydb "github.com/case-framework/case-backend/pkg/db/study"
 	"github.com/case-framework/case-backend/pkg/study/studyengine"
+	"github.com/case-framework/case-backend/pkg/study/types"
 	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
 	studyUtils "github.com/case-framework/case-backend/pkg/study/utils"
 	"go.mongodb.org/mongo-driver/bson"
@@ -442,6 +444,132 @@ func OnSubmitResponseForTempParticipant(instanceID string, studyKey string, part
 
 	result = pState.AssignedSurveys
 	return
+}
+
+type RunStudyActionProgressFn func(totalCount int64, processedCount int64)
+
+type RunStudyActionReq struct {
+	InstanceID           string
+	StudyKey             string
+	OnlyForParticipantID string
+	Rules                []types.Expression
+	OnProgressFn         RunStudyActionProgressFn
+}
+
+type RunStudyActionResult struct {
+	ParticipantCount               int64
+	ParticipantStateChangedPerRule []int64
+	Duration                       int64
+}
+
+func OnRunStudyAction(req RunStudyActionReq) (*RunStudyActionResult, error) {
+	if req.InstanceID == "" || req.StudyKey == "" {
+		return nil, errors.New("instanceID and studyKey are required")
+	}
+
+	filter := bson.M{
+		"studyStatus": bson.M{"$nin": []string{
+			studyTypes.PARTICIPANT_STUDY_STATUS_ACCOUNT_DELETED,
+			studyTypes.PARTICIPANT_STUDY_STATUS_TEMPORARY,
+		}},
+	}
+
+	if req.OnlyForParticipantID != "" {
+		filter = bson.M{
+			"participantID": req.OnlyForParticipantID,
+		}
+	}
+
+	study, err := studyDBService.GetStudy(req.InstanceID, req.StudyKey)
+	if err != nil {
+		return nil, err
+	}
+
+	count, err := studyDBService.GetParticipantCount(req.InstanceID, req.StudyKey, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &RunStudyActionResult{
+		ParticipantCount:               0,
+		ParticipantStateChangedPerRule: make([]int64, len(req.Rules)),
+		Duration:                       0,
+	}
+	start := time.Now().Unix()
+
+	if req.OnProgressFn != nil {
+		req.OnProgressFn(count, 0)
+	}
+
+	err = studyDBService.FindAndExecuteOnParticipantsStates(
+		context.Background(),
+		req.InstanceID,
+		req.StudyKey,
+		filter,
+		nil,
+		false,
+		func(dbService *studydb.StudyDBService, p studyTypes.Participant, instanceID, studyKey string, args ...interface{}) error {
+			result.ParticipantCount += 1
+
+			if req.OnProgressFn != nil {
+				req.OnProgressFn(count, result.ParticipantCount)
+			}
+
+			confidentialID, err := ComputeConfidentialIDForParticipant(study, p.ParticipantID)
+			if err != nil {
+				slog.Error("Error computing confidential ID", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("participantID", p.ParticipantID), slog.String("error", err.Error()))
+				return err
+			}
+
+			participantData := studyengine.ActionData{
+				PState:          p,
+				ReportsToCreate: map[string]studyTypes.Report{},
+			}
+
+			anyChange := false
+
+			for i, rule := range req.Rules {
+				event := studyengine.StudyEvent{
+					InstanceID:                            instanceID,
+					StudyKey:                              studyKey,
+					Type:                                  studyengine.STUDY_EVENT_TYPE_CUSTOM,
+					ParticipantIDForConfidentialResponses: confidentialID,
+				}
+
+				newState, err := studyengine.ActionEval(rule, participantData, event)
+				if err != nil {
+					slog.Error("Error evaluating study rule", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("participantID", p.ParticipantID), slog.String("rule", rule.Name), slog.String("error", err.Error()))
+					return err
+				}
+
+				if !reflect.DeepEqual(newState.PState, participantData.PState) {
+					result.ParticipantStateChangedPerRule[i] += 1
+					anyChange = true
+				}
+				participantData = newState
+			}
+
+			if anyChange {
+				_, err = studyDBService.SaveParticipantState(instanceID, studyKey, participantData.PState)
+				if err != nil {
+					slog.Error("Error saving participant state", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("participantID", p.ParticipantID), slog.String("error", err.Error()))
+					return err
+				}
+			}
+
+			saveReports(instanceID, studyKey, participantData.ReportsToCreate, studyengine.STUDY_EVENT_TYPE_CUSTOM)
+
+			result.Duration = time.Now().Unix() - start
+			return nil
+		},
+	)
+	if err != nil {
+		slog.Error("Error executing study action", slog.String("instanceID", req.InstanceID), slog.String("studyKey", req.StudyKey), slog.String("error", err.Error()))
+	}
+
+	result.Duration = time.Now().Unix() - start
+
+	return result, nil
 }
 
 // Run study timer event for participants

--- a/services/management-api/apihandlers/study-management.go
+++ b/services/management-api/apihandlers/study-management.go
@@ -1656,7 +1656,7 @@ func (h *HttpEndpoints) onActionTaskCompleted(
 		instanceID,
 		taskID,
 		studyTypes.TASK_STATUS_COMPLETED,
-		0,
+		int(results.ParticipantCount),
 		"",
 		relativeFilepath,
 	)

--- a/services/management-api/main.go
+++ b/services/management-api/main.go
@@ -6,9 +6,6 @@ import (
 	"time"
 
 	"github.com/case-framework/case-backend/pkg/apihelpers"
-	muDB "github.com/case-framework/case-backend/pkg/db/management-user"
-	"github.com/case-framework/case-backend/pkg/db/messaging"
-	studyDB "github.com/case-framework/case-backend/pkg/db/study"
 	"github.com/case-framework/case-backend/services/management-api/apihandlers"
 
 	"github.com/gin-contrib/cors"
@@ -18,23 +15,6 @@ import (
 var conf Config
 
 func main() {
-	// Connect to DBs
-	muDBService, err := muDB.NewManagementUserDBService(conf.ManagementUserDBConfig)
-	if err != nil {
-		slog.Error("Error connecting to Management User DB", slog.String("error", err.Error()))
-		return
-	}
-	messagingDBService, err := messaging.NewMessagingDBService(conf.MessagingDBConfig)
-	if err != nil {
-		slog.Error("Error connecting to Messaging DB", slog.String("error", err.Error()))
-		return
-	}
-
-	studyDBService, err := studyDB.NewStudyDBService(conf.StudyDBConfig)
-	if err != nil {
-		slog.Error("Error connecting to Study DB", slog.String("error", err.Error()))
-		return
-	}
 
 	// Start webserver
 	router := gin.Default()
@@ -59,7 +39,7 @@ func main() {
 		messagingDBService,
 		studyDBService,
 		conf.AllowedInstanceIDs,
-		conf.StudyGlobalSecret,
+		conf.StudyConfigs.GlobalSecret,
 		conf.FilestorePath,
 	)
 	v1APIHandlers.AddManagementAuthAPI(v1Root)


### PR DESCRIPTION
Implement endpoints for running study actions (custom rules) on participant states, or previous responses. 

To be able to use the study-service, the initialisation had to be extended with study service configs (to reach externalServices). To achieve this, we started to introduce reading the configs from a config file.

New env variable: `CONFIG_FILE_PATH` which should point to the location of the config yaml file.