### PR TITLE
Participant user deletion

### DIFF
--- a/pkg/permission-checker/constants.go
+++ b/pkg/permission-checker/constants.go
@@ -6,6 +6,7 @@ const (
 )
 
 const (
+	RESOURCE_TYPE_USERS     = "users"
 	RESOURCE_TYPE_STUDY     = "study"
 	RESOURCE_TYPE_MESSAGING = "messaging"
 )
@@ -44,6 +45,8 @@ const (
 	ACTION_GET_PARTICIPANT_STATES     = "get-participant-states"
 	ACTION_GET_REPORTS                = "get-reports"
 	ACTION_DELETE_REPORTS             = "delete-reports"
+
+	ACTION_DELETE_USERS = "delete-users"
 
 	ACTION_ALL = "*"
 )

--- a/services/management-api/apihandlers/handlers.go
+++ b/services/management-api/apihandlers/handlers.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"time"
 
+	globalinfosDB "github.com/case-framework/case-backend/pkg/db/global-infos"
 	muDB "github.com/case-framework/case-backend/pkg/db/management-user"
 	messagingDB "github.com/case-framework/case-backend/pkg/db/messaging"
+	userDB "github.com/case-framework/case-backend/pkg/db/participant-user"
 	studyDB "github.com/case-framework/case-backend/pkg/db/study"
 	"github.com/gin-gonic/gin"
 )
@@ -35,6 +37,8 @@ type HttpEndpoints struct {
 	muDBConn           *muDB.ManagementUserDBService
 	messagingDBConn    *messagingDB.MessagingDBService
 	studyDBConn        *studyDB.StudyDBService
+	participantUserDB  *userDB.ParticipantUserDBService
+	globalInfosDBConn  *globalinfosDB.GlobalInfosDBService
 	tokenSignKey       string
 	tokenExpiresIn     time.Duration
 	allowedInstanceIDs []string
@@ -48,6 +52,8 @@ func NewHTTPHandler(
 	muDBConn *muDB.ManagementUserDBService,
 	messagingDBConn *messagingDB.MessagingDBService,
 	studyDBConn *studyDB.StudyDBService,
+	participantUserDB *userDB.ParticipantUserDBService,
+	globalInfosDBConn *globalinfosDB.GlobalInfosDBService,
 	allowedInstanceIDs []string,
 	globalStudySecret string,
 	filestorePath string,
@@ -57,6 +63,8 @@ func NewHTTPHandler(
 		muDBConn:           muDBConn,
 		messagingDBConn:    messagingDBConn,
 		studyDBConn:        studyDBConn,
+		participantUserDB:  participantUserDB,
+		globalInfosDBConn:  globalInfosDBConn,
 		allowedInstanceIDs: allowedInstanceIDs,
 		globalStudySecret:  globalStudySecret,
 		tokenExpiresIn:     tokenExpiresIn,

--- a/services/management-api/main.go
+++ b/services/management-api/main.go
@@ -38,6 +38,8 @@ func main() {
 		muDBService,
 		messagingDBService,
 		studyDBService,
+		participantUserDBService,
+		globalInfosDBService,
 		conf.AllowedInstanceIDs,
 		conf.StudyConfigs.GlobalSecret,
 		conf.FilestorePath,


### PR DESCRIPTION
## General
Implementing management functionality to delete participant users (and mark their participants deleted in the study system).
To enable this, the management-api service needs configuration to the participant-user-db and the global-infos db. 

## Authorisation

The action to delete a participant-user can be performed by:
- admin users
- management-users with the permission: `users.*.delete-users`

## Config changes

In the environment variables, define following new entries:
- `PARTICIPANT_USER_DB_USERNAME`
- `PARTICIPANT_USER_DB_PASSWORD`
- `GLOBAL_INFOS_DB_USERNAME`
- `GLOBAL_INFOS_DB_PASSWORD`

In the `config.yaml` file define the variables (adapt values as it fits your setup):
```
...
db_configs:
  participant_user_db:
    connection_str: "<db-url>"
    connection_prefix: "<empty or +srv>"
    timeout: 30
    idle_conn_timeout: 45
    max_pool_size: 4
    use_no_cursor_timeout: false
    db_name_prefix: "<optional db name prefix>"
    run_index_creation: false
  global_infos_db:
    connection_str: "<db-url>"
    connection_prefix: "<empty or +srv>"
    timeout: 30
    idle_conn_timeout: 45
    max_pool_size: 4
    use_no_cursor_timeout: false
    db_name_prefix: "<optional db name prefix>"
    run_index_creation: false
    run_index_creation: false
```
