### PR TITLE
Reuse arrived at for response replay action

### DIFF
--- a/pkg/db/study/responses.go
+++ b/pkg/db/study/responses.go
@@ -55,7 +55,10 @@ func (dbService *StudyDBService) CreateIndexForResponsesCollection(instanceID st
 func (dbService *StudyDBService) AddSurveyResponse(instanceID string, studyKey string, response studyTypes.SurveyResponse) (string, error) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
-	response.ArrivedAt = time.Now().Unix()
+
+	if response.ArrivedAt == 0 {
+		response.ArrivedAt = time.Now().Unix()
+	}
 	res, err := dbService.collectionResponses(instanceID, studyKey).InsertOne(ctx, response)
 	id := res.InsertedID.(primitive.ObjectID)
 	return id.Hex(), err

--- a/pkg/study/study-service.go
+++ b/pkg/study/study-service.go
@@ -324,6 +324,8 @@ func OnMergeTempParticipant(instanceID string, studyKey string, profileID string
 }
 
 func OnSubmitResponse(instanceID string, studyKey string, profileID string, response studyTypes.SurveyResponse) (result []studyTypes.AssignedSurvey, err error) {
+	response.ArrivedAt = time.Now().Unix()
+
 	study, err := getStudyIfActive(instanceID, studyKey)
 	if err != nil {
 		slog.Error("error getting study", slog.String("error", err.Error()))
@@ -387,6 +389,8 @@ func OnSubmitResponse(instanceID string, studyKey string, profileID string, resp
 }
 
 func OnSubmitResponseForTempParticipant(instanceID string, studyKey string, participantID string, response studyTypes.SurveyResponse) (result []studyTypes.AssignedSurvey, err error) {
+	response.ArrivedAt = time.Now().Unix()
+
 	study, err := getStudyIfActive(instanceID, studyKey)
 	if err != nil {
 		slog.Error("error getting study", slog.String("error", err.Error()))
@@ -860,6 +864,9 @@ func OnLeaveStudy(instanceID string, studyKey string, profileID string) (result 
 }
 
 func OnProfileDeleted(instanceID, profileID string, exitSurveyResp *studyTypes.SurveyResponse) {
+	if exitSurveyResp != nil {
+		exitSurveyResp.ArrivedAt = time.Now().Unix()
+	}
 	studies, err := studyDBService.GetStudies(instanceID, "", false)
 	if err != nil {
 		slog.Error("Error getting studies by status", slog.String("instanceID", instanceID), slog.String("error", err.Error()))

--- a/pkg/study/studyengine/actions.go
+++ b/pkg/study/studyengine/actions.go
@@ -88,7 +88,11 @@ func updateLastSubmissionForSurvey(oldState ActionData, event StudyEvent) (newSt
 	if newState.PState.LastSubmissions == nil {
 		newState.PState.LastSubmissions = map[string]int64{}
 	}
-	newState.PState.LastSubmissions[event.Response.Key] = time.Now().Unix()
+
+	if event.Response.ArrivedAt == 0 {
+		event.Response.ArrivedAt = time.Now().Unix()
+	}
+	newState.PState.LastSubmissions[event.Response.Key] = event.Response.ArrivedAt
 	return
 }
 


### PR DESCRIPTION
Improve behaviour of replay action, so that it used actual arrivedAt attribute from the response to override the lastSubmissions list