### PR TITLE
Map to key for confidential questions

### DIFF
--- a/pkg/study/helpers.go
+++ b/pkg/study/helpers.go
@@ -85,8 +85,13 @@ func saveResponses(instanceID string, studyKey string, response studyTypes.Surve
 	// Save confidential data:
 	if len(confidentialResponses) > 0 {
 		for _, confItem := range confidentialResponses {
+			itemKey := confItem.Key
+			if len(confItem.MapToKey) > 0 {
+				itemKey = confItem.MapToKey
+				confItem.Key = itemKey
+			}
 			rItem := studyTypes.SurveyResponse{
-				Key:           confItem.Key,
+				Key:           itemKey,
 				ParticipantID: confidentialID,
 				Responses:     []studyTypes.SurveyItemResponse{confItem},
 			}

--- a/pkg/study/types/survey-item.go
+++ b/pkg/study/types/survey-item.go
@@ -25,6 +25,7 @@ type SurveyItem struct {
 	Components       *ItemComponent `bson:"components,omitempty" json:"components,omitempty"`
 	Validations      []Validation   `bson:"validations,omitempty" json:"validations,omitempty"`
 	ConfidentialMode string         `bson:"confidentialMode,omitempty" json:"confidentialMode,omitempty"`
+	MapToKey         string         `bson:"mapToKey,omitempty" json:"mapToKey,omitempty"` // map to this key for confidential mode
 }
 
 type Validation struct {

--- a/pkg/study/types/surveyResponse.go
+++ b/pkg/study/types/surveyResponse.go
@@ -24,6 +24,7 @@ type SurveyItemResponse struct {
 	// for single items:
 	Response         *ResponseItem `bson:"response,omitempty" json:"response,omitempty"`
 	ConfidentialMode string        `bson:"confidentialMode,omitempty" json:"confidentialMode,omitempty"`
+	MapToKey         string        `bson:"mapToKey,omitempty" json:"mapToKey,omitempty"` // map to this key for confidential mode
 }
 
 type ResponseMeta struct {


### PR DESCRIPTION
This pull request introduces changes to support mapping confidential survey responses to a different key. The main updates include adding a `MapToKey` field to relevant structs and adjusting the logic to use this field when saving confidential data.

### Enhancements to Confidential Data Handling:

* Updated the `saveResponses` function to use the `MapToKey` field for confidential survey responses, ensuring the correct key is used when saving data.
* Added a `MapToKey` field to the `SurveyItem` struct to specify an alternate key for confidential mode.
* Added a `MapToKey` field to the `SurveyItemResponse` struct to support mapping to a different key in confidential mode.