### PR TITLE
exporter should use arrived at

### DIFF
--- a/pkg/study/exporter/survey-responses/parser.go
+++ b/pkg/study/exporter/survey-responses/parser.go
@@ -56,6 +56,7 @@ func (rp *ResponseParser) initColumnNames(extraContextColumns *[]string) error {
 		"version",
 		"opened",
 		"submitted",
+		"arrived",
 	}
 
 	ctxCols := defaultCtxColNames
@@ -95,6 +96,7 @@ func (rp *ResponseParser) ParseResponse(
 		Version:       rawResp.VersionID,
 		OpenedAt:      rawResp.OpenedAt,
 		SubmittedAt:   rawResp.SubmittedAt,
+		ArrivedAt:     rawResp.ArrivedAt,
 		Context:       rawResp.Context,
 		Responses:     map[string]interface{}{},
 		Meta: ResponseMeta{
@@ -105,7 +107,7 @@ func (rp *ResponseParser) ParseResponse(
 		},
 	}
 
-	currentVersion, err := findSurveyVersion(rawResp.VersionID, rawResp.SubmittedAt, rp.surveyVersions)
+	currentVersion, err := findSurveyVersion(rawResp.VersionID, rawResp.ArrivedAt, rp.surveyVersions)
 	if err != nil {
 		return parsedResponse, err
 	}
@@ -258,6 +260,7 @@ func (rp ResponseParser) initWithFixedColumnsWithValues(
 		rp.columns.FixedColumns[2]: parsedResponse.Version,
 		rp.columns.FixedColumns[3]: parsedResponse.OpenedAt,
 		rp.columns.FixedColumns[4]: parsedResponse.SubmittedAt,
+		rp.columns.FixedColumns[5]: parsedResponse.ArrivedAt,
 	}
 }
 

--- a/pkg/study/exporter/survey-responses/types.go
+++ b/pkg/study/exporter/survey-responses/types.go
@@ -5,6 +5,7 @@ type ParsedResponse struct {
 	ParticipantID string
 	OpenedAt      int64
 	SubmittedAt   int64
+	ArrivedAt     int64
 	Version       string
 	Context       map[string]string // e.g. Language, or engine version
 	Responses     map[string]interface{}


### PR DESCRIPTION
Changes to support `ArrivedAt` timestamp:

* Added `arrived` to the list of column names in `initColumnNames`.
* Included `ArrivedAt` in the `ParseResponse` function to capture the arrival time of a response.
* Updated `findSurveyVersion` call to use `ArrivedAt` instead of `SubmittedAt` for version lookup.
* Added `ArrivedAt` to the fixed columns in `initWithFixedColumnsWithValues`.
* Added `ArrivedAt` field to the `ParsedResponse` struct.