### PR TITLE
Atomic otp creation with respecting limit

### DIFF
--- a/pkg/user-management/user-management.go
+++ b/pkg/user-management/user-management.go
@@ -67,7 +67,7 @@ func SendOTPByEmail(
 	}
 
 	// save OTP
-	err = pUserDBService.CreateOTP(instanceID, userID, code, userTypes.EmailOTP)
+	err = pUserDBService.CreateOTP(instanceID, userID, code, userTypes.EmailOTP, MAX_OTP_ATTEMPTS)
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func SendOTPBySMS(instanceID, userID string) error {
 	}
 
 	// save OTP
-	err = pUserDBService.CreateOTP(instanceID, userID, code, userTypes.SMSOTP)
+	err = pUserDBService.CreateOTP(instanceID, userID, code, userTypes.SMSOTP, MAX_OTP_ATTEMPTS)
 	if err != nil {
 		return err
 	}

--- a/services/participant-api/apihandlers/authentication.go
+++ b/services/participant-api/apihandlers/authentication.go
@@ -831,6 +831,7 @@ func (h *HttpEndpoints) requestOTP(c *gin.Context) {
 		)
 		if err != nil {
 			slog.Error("failed to send OTP by email", slog.String("error", err.Error()))
+			randomWait(2, 5)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
@@ -841,6 +842,7 @@ func (h *HttpEndpoints) requestOTP(c *gin.Context) {
 		)
 		if err != nil {
 			slog.Error("failed to send OTP by SMS", slog.String("error", err.Error()))
+			randomWait(2, 5)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}

--- a/services/participant-api/apihandlers/user-management.go
+++ b/services/participant-api/apihandlers/user-management.go
@@ -524,7 +524,7 @@ func (h *HttpEndpoints) requestPhoneNumberVerificationHandl(c *gin.Context) {
 	}
 
 	// save OTP
-	err = h.userDBConn.CreateOTP(token.InstanceID, token.Subject, code, userTypes.SMSOTP)
+	err = h.userDBConn.CreateOTP(token.InstanceID, token.Subject, code, userTypes.SMSOTP, MAX_PHONE_NUMBER_VERIFICATION_REQUEST_PER_24H)
 	if err != nil {
 		slog.Error("failed to save OTP", slog.String("instanceId", token.InstanceID), slog.String("userId", token.Subject), slog.String("error", err.Error()))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save OTP"})


### PR DESCRIPTION
Enforcing the limit to the number of OTPs that can be created for a user by using a transaction and incorporating random wait times to mitigate brute force attacks. 