### PR TITLE
Include sum and neg exps

### DIFF
--- a/pkg/study/studyengine/expressions.go
+++ b/pkg/study/studyengine/expressions.go
@@ -122,6 +122,11 @@ func ExpressionEval(expression studyTypes.Expression, evalCtx EvalContext) (val 
 		val, err = evalCtx.or(expression)
 	case "not":
 		val, err = evalCtx.not(expression)
+	// Math functions
+	case "sum":
+		val, err = evalCtx.sum(expression)
+	case "neg":
+		val, err = evalCtx.neg(expression)
 	// Other
 	case "timestampWithOffset":
 		val, err = evalCtx.timestampWithOffset(expression)
@@ -1345,6 +1350,45 @@ func (ctx EvalContext) not(exp studyTypes.Expression) (val bool, err error) {
 		}
 		return false, nil
 	}
+	return
+}
+
+func (ctx EvalContext) sum(exp studyTypes.Expression) (t float64, err error) {
+	for idx, dataExp := range exp.Data {
+		arg, err := ctx.expressionArgResolver(dataExp)
+		if err != nil {
+			slog.Error("unexpected error during expression eval", slog.Int("index", idx), slog.String("expression", exp.Name), slog.String("error", err.Error()))
+			continue
+		}
+		switch v := arg.(type) {
+		case bool:
+			if v {
+				t = t + 1
+			}
+		case float64:
+			t = t + v
+		default:
+			slog.Error("unexpected type during expression eval", slog.Int("index", idx), slog.String("expression", exp.Name), slog.String("type", reflect.TypeOf(arg).String()))
+		}
+
+	}
+	return
+}
+
+func (ctx EvalContext) neg(exp studyTypes.Expression) (val float64, err error) {
+	if len(exp.Data) != 1 {
+		return val, errors.New("should have one argument")
+	}
+
+	arg, err := ctx.expressionArgResolver(exp.Data[0])
+	if err != nil {
+		return val, err
+	}
+	if reflect.TypeOf(arg).Kind() != reflect.Float64 {
+		return val, errors.New("argument 1 should be resolved as type number (float64)")
+	}
+	v := arg.(float64)
+	val = -1 * v
 	return
 }
 

--- a/pkg/study/studyengine/expressions.go
+++ b/pkg/study/studyengine/expressions.go
@@ -376,7 +376,7 @@ func (ctx EvalContext) checkConditionForOldResponses(exp studyTypes.Expression) 
 }
 
 func (ctx EvalContext) hasEventPayload() (val bool, err error) {
-	return ctx.Event.Payload != nil && len(ctx.Event.Payload) > 0, nil
+	return len(ctx.Event.Payload) > 0, nil
 }
 
 func (ctx EvalContext) getEventPayloadValueAsStr(exp studyTypes.Expression) (val string, err error) {

--- a/pkg/study/studyengine/expressions_test.go
+++ b/pkg/study/studyengine/expressions_test.go
@@ -1,6 +1,7 @@
 package studyengine
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -2530,6 +2531,78 @@ func TestEvalNOT(t *testing.T) {
 			t.Errorf("unexpected value: %b", ret)
 		}
 	})
+}
+
+func TestEvalSum(t *testing.T) {
+
+	testAdd := func(expected float64, label string, values ...studyTypes.ExpressionArg) {
+
+		t.Run(fmt.Sprintf("Sum %s", label), func(t *testing.T) {
+			exp := studyTypes.Expression{Name: "sum", Data: values}
+			EvalContext := EvalContext{}
+			ret, err := ExpressionEval(exp, EvalContext)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err.Error())
+				return
+			}
+			resTS := ret.(float64)
+			if resTS != expected {
+				t.Errorf("unexpected value: %f - expected ca. %f", ret, expected)
+			}
+		})
+	}
+
+	argNum := func(v float64) studyTypes.ExpressionArg {
+		return studyTypes.ExpressionArg{DType: "num", Num: v}
+	}
+
+	argBool := func(v bool) studyTypes.ExpressionArg {
+		var vN float64
+		if v {
+			vN = 1
+		} else {
+			vN = 0
+		}
+		return studyTypes.ExpressionArg{
+			DType: "exp",
+			Exp:   &studyTypes.Expression{Name: "or", Data: []studyTypes.ExpressionArg{argNum(vN), argNum(vN)}},
+		}
+	}
+
+	testAdd(1, "0 + 1", argNum(0), argNum(1))
+	testAdd(2, "1 + 1", argNum(1), argNum(1))
+	testAdd(1, "-1 + 2", argNum(-1), argNum(2))
+	testAdd(3, "1+1+1", argNum(1), argNum(1), argNum(1))
+	testAdd(2, "true + true", argBool(true), argBool(true))
+	testAdd(0, "false + false", argBool(false), argBool(false))
+	testAdd(1, "true + false", argBool(true), argBool(false))
+	testAdd(1, "false + true", argBool(false), argBool(true))
+
+}
+
+func TestEvalNeg(t *testing.T) {
+
+	testNeg := func(v1 float64, expected float64) {
+		t.Run(fmt.Sprintf("Negate %f", v1), func(t *testing.T) {
+			exp := studyTypes.Expression{Name: "neg", Data: []studyTypes.ExpressionArg{
+				{DType: "num", Num: v1},
+			}}
+			EvalContext := EvalContext{}
+			ret, err := ExpressionEval(exp, EvalContext)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err.Error())
+				return
+			}
+			resTS := ret.(float64)
+			if resTS != expected {
+				t.Errorf("unexpected value: %f - expected ca. %f", ret, expected)
+			}
+		})
+	}
+
+	testNeg(0, 0)
+	testNeg(1, -1)
+	testNeg(-1, 1)
 }
 
 func TestEvalTimestampWithOffset(t *testing.T) {

--- a/pkg/study/studyengine/expressions_test.go
+++ b/pkg/study/studyengine/expressions_test.go
@@ -140,6 +140,56 @@ func TestEvalHasStudyStatus(t *testing.T) {
 	})
 }
 
+func TestEvalHasEventPayload(t *testing.T) {
+	evalHasEventPayload := func(payload map[string]interface{}) (interface{}, error) {
+		exp := studyTypes.Expression{Name: "hasEventPayload"}
+		evalContext := EvalContext{
+			Event: StudyEvent{
+				Payload: payload,
+			},
+		}
+		return ExpressionEval(exp, evalContext)
+	}
+
+	t.Run("Should return true if event payload is present", func(t *testing.T) {
+
+		payload := map[string]interface{}{
+			"test": "test",
+		}
+
+		ret, err := evalHasEventPayload(payload)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err.Error())
+			return
+		}
+		if !ret.(bool) {
+			t.Errorf("unexpected value: %b", ret)
+		}
+	})
+	t.Run("Should return false if event payload is not present", func(t *testing.T) {
+		payload := map[string]interface{}{}
+		ret, err := evalHasEventPayload(payload)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err.Error())
+			return
+		}
+		if ret.(bool) {
+			t.Errorf("unexpected value: %b", ret)
+		}
+	})
+
+	t.Run("Should return false if event payload is not present", func(t *testing.T) {
+		ret, err := evalHasEventPayload(nil)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err.Error())
+			return
+		}
+		if ret.(bool) {
+			t.Errorf("unexpected value: %b", ret)
+		}
+	})
+}
+
 type MockStudyDBService struct {
 	Responses []studyTypes.SurveyResponse
 }


### PR DESCRIPTION
Migrating content of https://github.com/influenzanet/study-service/pull/31

### New Mathematical Functions:
* Added `sum` function to evaluate the sum of numeric and boolean expressions. 
* Added `neg` function to evaluate the negation of a numeric expression.

### Function Modifications:
* Modified `hasEventPayload` function to simplify the return statement by removing unnecessary nil check. 

### Testing Enhancements:
* Added `TestEvalHasEventPayload` to verify the behavior of `hasEventPayload` function. 
* Added `TestEvalSum` to verify the behavior of the `sum` function with various inputs. 
* Added `TestEvalNeg` to verify the behavior of the `neg` function with various inputs. 