### PR TITLE
Study engine now

### DIFF
--- a/pkg/study/studyengine/actions.go
+++ b/pkg/study/studyengine/actions.go
@@ -90,7 +90,7 @@ func updateLastSubmissionForSurvey(oldState ActionData, event StudyEvent) (newSt
 	}
 
 	if event.Response.ArrivedAt == 0 {
-		event.Response.ArrivedAt = time.Now().Unix()
+		event.Response.ArrivedAt = Now().Unix()
 	}
 	newState.PState.LastSubmissions[event.Response.Key] = event.Response.ArrivedAt
 	return
@@ -590,7 +590,7 @@ func initReport(action studyTypes.Expression, oldState ActionData, event StudyEv
 	newState.ReportsToCreate[reportKey] = studyTypes.Report{
 		Key:           reportKey,
 		ParticipantID: oldState.PState.ParticipantID,
-		Timestamp:     time.Now().Truncate(time.Minute).Unix(),
+		Timestamp:     Now().Truncate(time.Minute).Unix(),
 	}
 	return
 }
@@ -622,7 +622,7 @@ func updateReportData(action studyTypes.Expression, oldState ActionData, event S
 		report = studyTypes.Report{
 			Key:           reportKey,
 			ParticipantID: oldState.PState.ParticipantID,
-			Timestamp:     time.Now().Truncate(time.Minute).Unix(),
+			Timestamp:     Now().Truncate(time.Minute).Unix(),
 		}
 	}
 

--- a/pkg/study/studyengine/actions_test.go
+++ b/pkg/study/studyengine/actions_test.go
@@ -9,6 +9,12 @@ import (
 )
 
 func TestActions(t *testing.T) {
+	// Override Now function for testing
+	originalNow := Now
+	defer func() { Now = originalNow }()
+	Now = func() time.Time {
+		return time.Unix(1609459200, 0) // Fixed time for testing: 2021-01-01 00:00:00 UTC
+	}
 
 	actionData := ActionData{
 		PState: studyTypes.Participant{
@@ -522,6 +528,12 @@ func TestActions(t *testing.T) {
 }
 
 func TestReportActions(t *testing.T) {
+	// Override Now function for testing
+	originalNow := Now
+	defer func() { Now = originalNow }()
+	Now = func() time.Time {
+		return time.Unix(1609459200, 0) // Fixed time for testing: 2021-01-01 00:00:00 UTC
+	}
 
 	actionData := ActionData{
 		PState: studyTypes.Participant{

--- a/pkg/study/studyengine/expressions.go
+++ b/pkg/study/studyengine/expressions.go
@@ -1406,7 +1406,7 @@ func (ctx EvalContext) timestampWithOffset(exp studyTypes.Expression) (t float64
 	}
 	delta := int64(arg1.(float64))
 
-	referenceTime := time.Now().Unix()
+	referenceTime := Now().Unix()
 	if len(exp.Data) == 2 {
 		arg2, err2 := ctx.expressionArgResolver(exp.Data[1])
 		if err2 != nil {
@@ -1442,7 +1442,7 @@ func (ctx EvalContext) getTsForNextISOWeek(exp studyTypes.Expression) (t float64
 		return t, errors.New("argument 1 should be between 1 and 53")
 	}
 
-	referenceTime := time.Now()
+	referenceTime := Now()
 	if len(exp.Data) == 2 {
 		arg2, err2 := ctx.expressionArgResolver(exp.Data[1])
 		if err2 != nil {

--- a/pkg/study/studyengine/helpers.go
+++ b/pkg/study/studyengine/helpers.go
@@ -4,9 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
 )
+
+// Now function control the current time used by the expressions.
+var Now func() time.Time = time.Now
 
 // Method to find survey item response in the array of responses
 func findSurveyItemResponse(responses []studyTypes.SurveyItemResponse, key string) (responseOfInterest *studyTypes.SurveyItemResponse, err error) {


### PR DESCRIPTION
This pull request introduces a new `Now` function to replace direct calls to `time.Now()` throughout the `studyengine` package. This change improves testability by allowing the current time to be overridden in tests. The most important changes include modifying various functions to use the new `Now` function and updating tests to leverage this functionality.
(Replicate changes from https://github.com/influenzanet/study-service/pull/32) 