### PR TITLE
change to POST

### DIFF
--- a/services/management-api/apihandlers/study-management.go
+++ b/services/management-api/apihandlers/study-management.go
@@ -512,7 +512,7 @@ func (h *HttpEndpoints) addStudyDataExporterEndpoints(rg *gin.RouterGroup) {
 		))
 
 		// start export generation for responses
-		responsesGroup.GET("/", h.useAuthorisedHandler(
+		responsesGroup.POST("/", h.useAuthorisedHandler(
 			RequiredPermission{
 				ResourceType:        pc.RESOURCE_TYPE_STUDY,
 				ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
@@ -563,7 +563,7 @@ func (h *HttpEndpoints) addStudyDataExporterEndpoints(rg *gin.RouterGroup) {
 		))
 
 		// start export generation for participants
-		participantsGroup.GET("/", h.useAuthorisedHandler(
+		participantsGroup.POST("/", h.useAuthorisedHandler(
 			RequiredPermission{
 				ResourceType:        pc.RESOURCE_TYPE_STUDY,
 				ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
@@ -614,7 +614,7 @@ func (h *HttpEndpoints) addStudyDataExporterEndpoints(rg *gin.RouterGroup) {
 		))
 
 		// start export generation for reports
-		reportsGroup.GET("/", h.useAuthorisedHandler(
+		reportsGroup.POST("/", h.useAuthorisedHandler(
 			RequiredPermission{
 				ResourceType:        pc.RESOURCE_TYPE_STUDY,
 				ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
@@ -2620,7 +2620,7 @@ func parseSlots(respItem *studyTypes.ResponseItem, slotKey string) map[string]st
 		currentSlotKey = slotKey + respItem.Key
 	}
 
-	if respItem.Items == nil || len(respItem.Items) == 0 {
+	if len(respItem.Items) == 0 {
 		parsedResp[currentSlotKey] = respItem.Value
 		return parsedResp
 	}


### PR DESCRIPTION
## Changes in HTTP methods:

* Changed the HTTP method from `GET` to `POST` for starting export generation for responses in `addStudyDataExporterEndpoints` function.
* Changed the HTTP method from `GET` to `POST` for starting export generation for participants in `addStudyDataExporterEndpoints` function.
* Changed the HTTP method from `GET` to `POST` for starting export generation for reports in `addStudyDataExporterEndpoints` function.

Recommendation from security screening (ID: NCC-E012650-CAT)
> GET requests are not protected by CSRF controls and may be abused by an attacker to perform that action.

## Code simplification:

* Simplified the conditional check for `respItem.Items` in the `parseSlots` function by removing the `nil` check.