### PR TITLE
make participant flags available by templates

### DIFF
--- a/jobs/messaging/participant-messages.go
+++ b/jobs/messaging/participant-messages.go
@@ -102,6 +102,11 @@ func handleParticipantMessages(wg *sync.WaitGroup) {
 							payload["loginToken"] = loginToken
 						}
 
+						// include participant flags into payload:
+						for k, v := range p.Flags {
+							payload["flags."+k] = v
+						}
+
 						subject, content, err := emailsending.GenerateEmailContent(template, user.Account.PreferredLanguage, payload)
 						if err != nil {
 							counters.IncreaseCounter(false)


### PR DESCRIPTION
This pull request includes a change to the `handleParticipantMessages` function in the `jobs/messaging/participant-messages.go` file. The change involves adding participant flags to the payload when generating email content.

Improvements to payload handling:

* [`jobs/messaging/participant-messages.go`](diffhunk://#diff-be928a8c7070f8c14eb1d7e07dcb7392b0174545a3e3d58b66d4529538af03a0R105-R109): Added a loop to include participant flags into the payload before generating email content.

To use a flag value in the template, use:
`{{ index . "flags.<keyOfTheFlag>"}}`

E.g.: `{{ index . "flags.inviteCode"}}`