### PR TITLE
logging can use a build-info.yaml file to output extra infos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ management-api.yaml
 study-daily-data-export.yaml
 smtp-bridge-emulator.yaml
 run-smtp-bridge-emulator.sh
+build-info.yaml

--- a/jobs/messaging/init.go
+++ b/jobs/messaging/init.go
@@ -101,6 +101,7 @@ func init() {
 		conf.Logging.MaxAge,
 		conf.Logging.MaxBackups,
 		conf.Logging.CompressOldLogs,
+		conf.Logging.IncludeBuildInfo,
 	)
 
 	// Override secrets from environment variables

--- a/jobs/study-daily-data-export/init.go
+++ b/jobs/study-daily-data-export/init.go
@@ -74,6 +74,7 @@ func init() {
 		conf.Logging.MaxAge,
 		conf.Logging.MaxBackups,
 		conf.Logging.CompressOldLogs,
+		conf.Logging.IncludeBuildInfo,
 	)
 
 	// Override secrets from environment variables

--- a/jobs/study-timer/init.go
+++ b/jobs/study-timer/init.go
@@ -69,6 +69,7 @@ func init() {
 		conf.Logging.MaxAge,
 		conf.Logging.MaxBackups,
 		conf.Logging.CompressOldLogs,
+		conf.Logging.IncludeBuildInfo,
 	)
 
 	// Override secrets from environment variables

--- a/jobs/user-management/init.go
+++ b/jobs/user-management/init.go
@@ -99,6 +99,7 @@ func init() {
 		conf.Logging.MaxAge,
 		conf.Logging.MaxBackups,
 		conf.Logging.CompressOldLogs,
+		conf.Logging.IncludeBuildInfo,
 	)
 
 	// Override secrets from environment variables

--- a/pkg/utils/logUtils.go
+++ b/pkg/utils/logUtils.go
@@ -1,25 +1,51 @@
 package utils
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"gopkg.in/natefinch/lumberjack.v2"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	buildInfoFilename = "build-info.yaml"
+	buildInfoPrefix   = "build."
+)
+
+type BuildInfoMode int
+
+const (
+	BuildInfoNever BuildInfoMode = iota
+	BuildInfoOnce
+	BuildInfoAlways
 )
 
 type LoggerConfig struct {
-	LogToFile       bool   `json:"log_to_file" yaml:"log_to_file"`
-	Filename        string `json:"filename" yaml:"filename"`
-	MaxSize         int    `json:"max_size" yaml:"max_size"`
-	MaxAge          int    `json:"max_age" yaml:"max_age"`
-	MaxBackups      int    `json:"max_backups" yaml:"max_backups"`
-	LogLevel        string `json:"log_level" yaml:"log_level"`
-	IncludeSrc      bool   `json:"include_src" yaml:"include_src"`
-	CompressOldLogs bool   `json:"compress_old_logs" yaml:"compress_old_logs"`
+	LogToFile        bool   `json:"log_to_file" yaml:"log_to_file"`
+	Filename         string `json:"filename" yaml:"filename"`
+	MaxSize          int    `json:"max_size" yaml:"max_size"`
+	MaxAge           int    `json:"max_age" yaml:"max_age"`
+	MaxBackups       int    `json:"max_backups" yaml:"max_backups"`
+	LogLevel         string `json:"log_level" yaml:"log_level"`
+	IncludeSrc       bool   `json:"include_src" yaml:"include_src"`
+	CompressOldLogs  bool   `json:"compress_old_logs" yaml:"compress_old_logs"`
+	IncludeBuildInfo string `json:"include_build_info" yaml:"include_build_info"` // never, always, once
+}
+
+type CustomHandler struct {
+	slog.Handler
+	buildInfoAttrs []slog.Attr
+}
+
+func (h *CustomHandler) Handle(ctx context.Context, r slog.Record) error {
+	r.AddAttrs(h.buildInfoAttrs...)
+	return h.Handler.Handle(ctx, r)
 }
 
 func InitLogger(
@@ -31,7 +57,15 @@ func InitLogger(
 	logFileMaxAge int,
 	logFileMaxBackups int,
 	compressOldLogs bool,
+	includeBuildInfo string,
 ) {
+
+	usebuildInfo := getBuildInfoMode(includeBuildInfo)
+
+	buildInfoAttrs := []slog.Attr{}
+	if usebuildInfo != BuildInfoNever {
+		buildInfoAttrs = loadBuildInfoAsSlogAttrs(buildInfoFilename, buildInfoPrefix)
+	}
 
 	opts := &slog.HandlerOptions{
 		Level:     logLevelFromString(logLevel),
@@ -48,6 +82,7 @@ func InitLogger(
 		},
 	}
 
+	var logger *slog.Logger
 	if logToFile && logFilename != "" {
 		logTarget := &lumberjack.Logger{
 			Filename:   logFilename,
@@ -59,12 +94,27 @@ func InitLogger(
 
 		w := io.MultiWriter(os.Stdout, logTarget)
 		handler := slog.NewJSONHandler(w, opts)
-		logger := slog.New(handler)
-		slog.SetDefault(logger)
+		logger = slog.New(handler)
 	} else {
 		handler := slog.NewJSONHandler(os.Stdout, opts)
-		logger := slog.New(handler)
-		slog.SetDefault(logger)
+		logger = slog.New(handler)
+	}
+
+	if usebuildInfo == BuildInfoAlways {
+		for _, attr := range buildInfoAttrs {
+			logger = logger.With(attr)
+		}
+
+	}
+
+	slog.SetDefault(logger)
+
+	if usebuildInfo == BuildInfoOnce {
+		attrs := make([]any, len(buildInfoAttrs))
+		for i, attr := range buildInfoAttrs {
+			attrs[i] = attr
+		}
+		slog.Info("Build info", attrs...)
 	}
 }
 
@@ -83,38 +133,35 @@ func logLevelFromString(level string) slog.Level {
 	}
 }
 
-func ReadConfigFromEnvAndInitLogger(
-	envLogLevel string,
-	envLogIncludeSrc string,
-	envLogToFile string,
-	envLogFilename string,
-	envLogMaxSize string,
-	envLogMaxAge string,
-	envLogMaxBackups string,
-) {
-	level := os.Getenv(envLogLevel)
-	includeSrc := os.Getenv(envLogIncludeSrc) == "true"
-	logToFile := os.Getenv(envLogToFile) == "true"
-
-	if !logToFile {
-		InitLogger(level, includeSrc, logToFile, "", 0, 0, 0, true)
-		return
+func getBuildInfoMode(includeBuildInfo string) BuildInfoMode {
+	switch includeBuildInfo {
+	case "never":
+		return BuildInfoNever
+	case "always":
+		return BuildInfoAlways
+	case "once":
+		return BuildInfoOnce
+	default:
+		return BuildInfoNever
 	}
+}
 
-	logFilename := os.Getenv(envLogFilename)
-	logFileMaxSize, err := strconv.Atoi(os.Getenv(envLogMaxSize))
+func loadBuildInfoAsSlogAttrs(filename, prefix string) []slog.Attr {
+	data, err := os.ReadFile(filename)
 	if err != nil {
-		panic(err)
-	}
-	logFileMaxAge, err := strconv.Atoi(os.Getenv(envLogMaxAge))
-	if err != nil {
-		panic(err)
+		panic("Error reading build info file: " + err.Error())
 	}
 
-	logFileMaxBackups, err := strconv.Atoi(os.Getenv(envLogMaxBackups))
-	if err != nil {
-		panic(err)
+	buildInfo := make(map[string]string)
+	if err := yaml.Unmarshal(data, &buildInfo); err != nil {
+		panic("Error parsing build info: " + err.Error())
 	}
 
-	InitLogger(level, includeSrc, logToFile, logFilename, logFileMaxSize, logFileMaxAge, logFileMaxBackups, true)
+	attrs := make([]slog.Attr, 0, len(buildInfo))
+	for k, v := range buildInfo {
+		prefixedKey := fmt.Sprintf("%s%s", prefix, k)
+		attrs = append(attrs, slog.String(prefixedKey, v))
+	}
+
+	return attrs
 }

--- a/services/management-api/init.go
+++ b/services/management-api/init.go
@@ -54,14 +54,6 @@ const (
 
 	ENV_STUDY_GLOBAL_SECRET = "STUDY_GLOBAL_SECRET"
 
-	ENV_LOG_TO_FILE     = "LOG_TO_FILE"
-	ENV_LOG_FILENAME    = "LOG_FILENAME"
-	ENV_LOG_MAX_SIZE    = "LOG_MAX_SIZE"
-	ENV_LOG_MAX_AGE     = "LOG_MAX_AGE"
-	ENV_LOG_MAX_BACKUPS = "LOG_MAX_BACKUPS"
-	ENV_LOG_LEVEL       = "LOG_LEVEL"
-	ENV_LOG_INCLUDE_SRC = "LOG_INCLUDE_SRC"
-
 	ENV_FILESTORE_PATH = "FILESTORE_PATH"
 )
 
@@ -74,6 +66,9 @@ var (
 )
 
 type Config struct {
+	// Logging configs
+	Logging utils.LoggerConfig `json:"logging" yaml:"logging"`
+
 	// Gin configs
 	GinDebugMode bool     `json:"gin_debug_mode"`
 	AllowOrigins []string `json:"allow_origins"`
@@ -109,16 +104,6 @@ type Config struct {
 }
 
 func init() {
-	utils.ReadConfigFromEnvAndInitLogger(
-		ENV_LOG_LEVEL,
-		ENV_LOG_INCLUDE_SRC,
-		ENV_LOG_TO_FILE,
-		ENV_LOG_FILENAME,
-		ENV_LOG_MAX_SIZE,
-		ENV_LOG_MAX_AGE,
-		ENV_LOG_MAX_BACKUPS,
-	)
-
 	conf = initConfig()
 	if !conf.GinDebugMode {
 		gin.SetMode(gin.ReleaseMode)
@@ -203,6 +188,19 @@ func initConfig() Config {
 		fmt.Println("Error reading config file: " + err.Error())
 		conf = Config{}
 	}
+
+	// Init logger:
+	utils.InitLogger(
+		conf.Logging.LogLevel,
+		conf.Logging.IncludeSrc,
+		conf.Logging.LogToFile,
+		conf.Logging.Filename,
+		conf.Logging.MaxSize,
+		conf.Logging.MaxAge,
+		conf.Logging.MaxBackups,
+		conf.Logging.CompressOldLogs,
+		conf.Logging.IncludeBuildInfo,
+	)
 
 	conf.GinDebugMode = os.Getenv(ENV_GIN_DEBUG_MODE) == "true"
 	conf.Port = os.Getenv(ENV_MANAGEMENT_API_LISTEN_PORT)

--- a/services/participant-api/init.go
+++ b/services/participant-api/init.go
@@ -131,6 +131,7 @@ func init() {
 		conf.Logging.MaxAge,
 		conf.Logging.MaxBackups,
 		conf.Logging.CompressOldLogs,
+		conf.Logging.IncludeBuildInfo,
 	)
 
 	// Override secrets from environment variables

--- a/services/smtp-bridge/init.go
+++ b/services/smtp-bridge/init.go
@@ -54,6 +54,7 @@ func init() {
 		conf.Logging.MaxAge,
 		conf.Logging.MaxBackups,
 		conf.Logging.CompressOldLogs,
+		conf.Logging.IncludeBuildInfo,
 	)
 
 	if !conf.GinConfig.DebugMode {


### PR DESCRIPTION
This pull request introduces significant updates to the logging configuration across multiple services. The changes include adding support for including build information in logs, refactoring the logger initialization, and updating configurations to accommodate these new features.

## Breaking management-api config change

- removing the possibility to configure logging through env variables for the management-api
  - the env variables are not used anymore (can be removed):  `LOG_TO_FILE, LOG_FILENAME, LOG_MAX_SIZE, LOG_MAX_AGE, LOG_MAX_BACKUPS, LOG_LEVEL, LOG_INCLUDE_SRC`
  - in the config.yaml include the logging configs:
```
...
logging:
  log_level: "debug"
  include_src: true
  log_to_file: true
  filename: "./logs/management-api.log"
  max_size: 1
  max_backups: 100
  max_age: 28
  compress_old_logs: true
  include_build_info: "always"
... 
```

## New config option for logging:

`include_build_info` - possible values: empty, "never", "once", "always"

- If left empty, defaults to "never" or set to "never": behaviour of the logging as before. 
- "once" and "always": require the presence of the `build-info.yaml` at a location where it can be opened without setting a path. If the file cannot be read, or parsed, the application will panic and print the error.
  - "once": print the content from build-info.yaml once after the logger was initialised.
  - "always": print the content from build-info.yaml for each log line. 
  - for both cases, keys from the build-info.yaml are prefixed with `build.`

For example a build-info.yaml:
```
version: management-api@v1.0.0

```

Will result in:
```
{ 
  "time":"2024-12-19T14:41:01.999079+01:00",
  "level":"INFO",
  "source":{"function":"/pkg/utils.InitLogger","file":"logUtils.go","line":117},
  "msg":"Build info",
  "build.version":"management-api@v1.0.0"
}
```