### PR TITLE
can override api keys from env variable

### DIFF
--- a/services/smtp-bridge-emulator/init.go
+++ b/services/smtp-bridge-emulator/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log/slog"
 	"os"
+	"strings"
 
 	smtp_client "github.com/case-framework/case-backend/pkg/smtp-client"
 	"github.com/case-framework/case-backend/pkg/utils"
@@ -12,6 +13,9 @@ import (
 // Environment variables
 const (
 	ENV_CONFIG_FILE_PATH = "CONFIG_FILE_PATH"
+
+	// Variables to override "secrets" in the config file
+	ENV_API_KEYS = "API_KEYS"
 )
 
 type config struct {
@@ -58,11 +62,26 @@ func init() {
 		conf.Logging.IncludeBuildInfo,
 	)
 
+	overrideFromEnv()
+
 	if len(conf.ApiKeys) == 0 {
 		panic("No API keys provided for SMTP Bridge API.")
 	}
 
 	if conf.EmailsDir == "" {
 		panic("Emails directory to store emails not provided for SMTP Bridge Emulator API.")
+	}
+}
+
+func overrideFromEnv() {
+	// Override secrets from environment variables
+	if apiKeys := os.Getenv(ENV_API_KEYS); apiKeys != "" {
+		conf.ApiKeys = []string{}
+		for _, apiKey := range strings.Split(apiKeys, ",") {
+			key := strings.TrimSpace(apiKey)
+			if key != "" {
+				conf.ApiKeys = append(conf.ApiKeys, key)
+			}
+		}
 	}
 }

--- a/services/smtp-bridge/init.go
+++ b/services/smtp-bridge/init.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	smtp_client "github.com/case-framework/case-backend/pkg/smtp-client"
 	"github.com/case-framework/case-backend/pkg/utils"
@@ -12,6 +13,9 @@ import (
 // Environment variables
 const (
 	ENV_CONFIG_FILE_PATH = "CONFIG_FILE_PATH"
+
+	// Variables to override "secrets" in the config file
+	ENV_API_KEYS = "API_KEYS"
 )
 
 type config struct {
@@ -61,8 +65,23 @@ func init() {
 		gin.SetMode(gin.ReleaseMode)
 	}
 
+	overrideFromEnv()
+
 	if len(conf.ApiKeys) == 0 {
 		panic("No API keys provided for SMTP Bridge API.")
 	}
 
+}
+
+func overrideFromEnv() {
+	// Override secrets from environment variables
+	if apiKeys := os.Getenv(ENV_API_KEYS); apiKeys != "" {
+		conf.ApiKeys = []string{}
+		for _, apiKey := range strings.Split(apiKeys, ",") {
+			key := strings.TrimSpace(apiKey)
+			if key != "" {
+				conf.ApiKeys = append(conf.ApiKeys, key)
+			}
+		}
+	}
 }


### PR DESCRIPTION
This pull request includes changes to the `services/smtp-bridge-emulator/init.go` and `services/smtp-bridge/init.go` files to add functionality for overriding API keys from environment variables. The most important changes include adding the `overrideFromEnv` function and updating the initialization process to call this function.

Enhancements to environment variable handling:

* [`services/smtp-bridge-emulator/init.go`](diffhunk://#diff-c689b67aedc91055a86e327fdceadb1c2ead674389a17f61cbfb23641c64fbc4R75-R87): Added `overrideFromEnv` function to override secrets from environment variables and updated the initialization process to call this function. [[1]](diffhunk://#diff-c689b67aedc91055a86e327fdceadb1c2ead674389a17f61cbfb23641c64fbc4R75-R87) [[2]](diffhunk://#diff-c689b67aedc91055a86e327fdceadb1c2ead674389a17f61cbfb23641c64fbc4R65-R66)
* [`services/smtp-bridge/init.go`](diffhunk://#diff-bf7ce495c28e56954f1c7375d62c9852457cf64f2525027221ecdb09c2618975R68-R87): Added `overrideFromEnv` function to override secrets from environment variables and updated the initialization process to call this function.

Imports and constants updates:

* [`services/smtp-bridge-emulator/init.go`](diffhunk://#diff-c689b67aedc91055a86e327fdceadb1c2ead674389a17f61cbfb23641c64fbc4R6): Added `strings` package import and `ENV_API_KEYS` constant for environment variable handling. [[1]](diffhunk://#diff-c689b67aedc91055a86e327fdceadb1c2ead674389a17f61cbfb23641c64fbc4R6) [[2]](diffhunk://#diff-c689b67aedc91055a86e327fdceadb1c2ead674389a17f61cbfb23641c64fbc4R16-R18)
* [`services/smtp-bridge/init.go`](diffhunk://#diff-bf7ce495c28e56954f1c7375d62c9852457cf64f2525027221ecdb09c2618975R5): Added `strings` package import and `ENV_API_KEYS` constant for environment variable handling. [[1]](diffhunk://#diff-bf7ce495c28e56954f1c7375d62c9852457cf64f2525027221ecdb09c2618975R5) [[2]](diffhunk://#diff-bf7ce495c28e56954f1c7375d62c9852457cf64f2525027221ecdb09c2618975R16-R18)