### PR TITLE
Exporter fix matrix & cloze

### DIFF
--- a/pkg/study/exporter/survey-responses/questionTypeHandlers.go
+++ b/pkg/study/exporter/survey-responses/questionTypeHandlers.go
@@ -305,15 +305,19 @@ func (h *MatrixHandler) ParseResponse(question sd.SurveyQuestion, response *stud
 			}
 		} else {
 			if rGroup != nil {
-				if len(rGroup.Items) != 1 {
-					slog.Debug("unexpected response group for question", slog.String("questionKey", question.ID))
-				} else {
-					selection := rGroup.Items[0]
-					value := selection.Key
-					if selection.Value != "" {
-						value = selection.Value
+				if rSlot.ResponseType == sd.QUESTION_TYPE_MATRIX_DROPDOWN || rSlot.ResponseType == sd.QUESTION_TYPE_MATRIX_RADIO_ROW {
+					if len(rGroup.Items) != 1 {
+						slog.Debug("unexpected response group for question", slog.String("questionKey", question.ID))
+					} else {
+						selection := rGroup.Items[0]
+						value := selection.Key
+						if selection.Value != "" {
+							value = selection.Value
+						}
+						responseCols[slotKey] = value
 					}
-					responseCols[slotKey] = value
+				} else {
+					responseCols[slotKey] = rGroup.Value
 				}
 			}
 		}

--- a/pkg/study/exporter/survey-responses/questionTypeUtils.go
+++ b/pkg/study/exporter/survey-responses/questionTypeUtils.go
@@ -210,26 +210,24 @@ func parseSimpleCloze(questionKey string, responseSlotDef sd.ResponseDef, respon
 		for _, item := range rGroup.Items {
 			valueKey := questionKey + questionOptionSep + item.Key
 
-			if _, hasKey := responseCols[valueKey]; hasKey {
-				dropdown := false
+			dropdown := false
 
-				// Check if dropdown
-				for _, option := range responseSlotDef.Options {
-					if option.ID == item.Key && option.OptionType == sd.OPTION_TYPE_DROPDOWN {
-						dropdown = true
-						break
-					}
+			// Check if dropdown
+			for _, option := range responseSlotDef.Options {
+				if option.ID == item.Key && option.OptionType == sd.OPTION_TYPE_DROPDOWN {
+					dropdown = true
+					break
 				}
+			}
 
-				if dropdown {
-					if len(item.Items) != 1 {
-						slog.Debug("multiple responses for dropdown in cloze", slog.String("questionKey", questionKey), slog.String("itemKey", item.Key))
-					} else {
-						responseCols[valueKey] = item.Items[0].Key
-					}
+			if dropdown {
+				if len(item.Items) != 1 {
+					slog.Debug("multiple responses for dropdown in cloze", slog.String("questionKey", questionKey), slog.String("itemKey", item.Key))
 				} else {
-					responseCols[valueKey] = item.Value
+					responseCols[valueKey] = item.Items[0].Key
 				}
+			} else {
+				responseCols[valueKey] = item.Value
 			}
 		}
 	}
@@ -248,26 +246,24 @@ func parseClozeList(questionKey string, responseSlotDefs []sd.ResponseDef, respo
 		for _, item := range rGroup.Items {
 			valueKey := questionKey + questionOptionSep + rSlot.ID + "." + item.Key
 
-			if _, hasKey := responseCols[valueKey]; hasKey {
-				dropdown := false
+			dropdown := false
 
-				// Check if dropdown
-				for _, option := range rSlot.Options {
-					if option.ID == item.Key && option.OptionType == sd.OPTION_TYPE_DROPDOWN {
-						dropdown = true
-						break
-					}
+			// Check if dropdown
+			for _, option := range rSlot.Options {
+				if option.ID == item.Key && option.OptionType == sd.OPTION_TYPE_DROPDOWN {
+					dropdown = true
+					break
 				}
+			}
 
-				if dropdown {
-					if len(item.Items) != 1 {
-						slog.Debug("multiple responses for dropdown in cloze", slog.String("questionKey", questionKey), slog.String("responseSlotID", rSlot.ID), slog.String("itemKey", item.Key))
-					} else {
-						responseCols[valueKey] = item.Items[0].Key
-					}
+			if dropdown {
+				if len(item.Items) != 1 {
+					slog.Debug("multiple responses for dropdown in cloze", slog.String("questionKey", questionKey), slog.String("responseSlotID", rSlot.ID), slog.String("itemKey", item.Key))
 				} else {
-					responseCols[valueKey] = item.Value
+					responseCols[valueKey] = item.Items[0].Key
 				}
+			} else {
+				responseCols[valueKey] = item.Value
 			}
 		}
 	}


### PR DESCRIPTION
This pull request includes changes to the `pkg/study/exporter/survey-responses` package, focusing on improving the handling of survey responses. The most important changes include adding conditions for matrix dropdown and radio row types, and removing redundant checks in the `parseSimpleCloze` and `parseClozeList` functions.

Improvements to survey response handling:

* [`pkg/study/exporter/survey-responses/questionTypeHandlers.go`](diffhunk://#diff-97bbdc712de1e8329bdc38ec78e6d4aa327ef244d2045a8653cd05852cab6b3fR308): Added conditions to handle `QUESTION_TYPE_MATRIX_DROPDOWN` and `QUESTION_TYPE_MATRIX_RADIO_ROW` in the `ParseResponse` method. [[1]](diffhunk://#diff-97bbdc712de1e8329bdc38ec78e6d4aa327ef244d2045a8653cd05852cab6b3fR308) [[2]](diffhunk://#diff-97bbdc712de1e8329bdc38ec78e6d4aa327ef244d2045a8653cd05852cab6b3fR319-R321)

Code simplification:

* [`pkg/study/exporter/survey-responses/questionTypeUtils.go`](diffhunk://#diff-e80bf410f9b9224299e1e6e03422bf6f4592197745a2e2c46892ce4fbd00e151L213): Removed redundant checks for existing keys in the `parseSimpleCloze` and `parseClozeList` functions. [[1]](diffhunk://#diff-e80bf410f9b9224299e1e6e03422bf6f4592197745a2e2c46892ce4fbd00e151L213) [[2]](diffhunk://#diff-e80bf410f9b9224299e1e6e03422bf6f4592197745a2e2c46892ce4fbd00e151L235) [[3]](diffhunk://#diff-e80bf410f9b9224299e1e6e03422bf6f4592197745a2e2c46892ce4fbd00e151L251) [[4]](diffhunk://#diff-e80bf410f9b9224299e1e6e03422bf6f4592197745a2e2c46892ce4fbd00e151L273)