### PR TITLE
replace linebreaks with tag in csv export

### DIFF
--- a/pkg/study/exporter/survey-responses/parser.go
+++ b/pkg/study/exporter/survey-responses/parser.go
@@ -190,7 +190,9 @@ func (rp *ResponseParser) ResponseToStrList(
 
 	// add response item columns
 	for _, colName := range rp.columns.ResponseColumns {
-		out = append(out, valueToStr(result[colName]))
+		str := valueToStr(result[colName])
+		str = replaceNewlines(str)
+		out = append(out, str)
 	}
 
 	// add meta columns
@@ -224,7 +226,9 @@ func (rp *ResponseParser) ResponseToLongFormat(
 		currentRespLine := []string{}
 		currentRespLine = append(currentRespLine, fixedValues...)
 		currentRespLine = append(currentRespLine, colName)
-		currentRespLine = append(currentRespLine, valueToStr(result[colName]))
+		str := valueToStr(result[colName])
+		str = replaceNewlines(str)
+		currentRespLine = append(currentRespLine, str)
 		out = append(out, currentRespLine)
 	}
 

--- a/pkg/study/exporter/survey-responses/utils.go
+++ b/pkg/study/exporter/survey-responses/utils.go
@@ -50,6 +50,12 @@ func valueToStr(resultVal interface{}) string {
 	return str
 }
 
+func replaceNewlines(str string) string {
+	newStr := strings.ReplaceAll(str, "\r\n", "<br />")
+	newStr = strings.ReplaceAll(newStr, "\n", "<br />")
+	return newStr
+}
+
 func findResponse(responses []studytypes.SurveyItemResponse, key string) *studytypes.SurveyItemResponse {
 	for _, r := range responses {
 		if r.Key == key {


### PR DESCRIPTION
This pull request includes changes to the `pkg/study/exporter/survey-responses` package to handle newline characters in survey responses. The intention behind this change is to allow a wider range of CSV parsers / software, to correctly and simply import response export files.

Improvements to handling newline characters:

* [`pkg/study/exporter/survey-responses/utils.go`](diffhunk://#diff-0a3c370af351650b6d16c1b55537f67342643899cc8e4f7bef72ca61c5bca162R53-R58): Added a new function `replaceNewlines` to replace newline characters with `<br />` in strings.

Updates to existing methods:

* [`pkg/study/exporter/survey-responses/parser.go`](diffhunk://#diff-2194e410de996ffdb5b9a0a51609e4d63c1ee5aa4f82b179ab7aeee17d967a09L193-R195): Updated the `ResponseToStrList` method to use the new `replaceNewlines` function for each response item column.
* [`pkg/study/exporter/survey-responses/parser.go`](diffhunk://#diff-2194e410de996ffdb5b9a0a51609e4d63c1ee5aa4f82b179ab7aeee17d967a09L227-R231): Updated the `ResponseToLongFormat` method to use the new `replaceNewlines` function for each response item column.