### PR TITLE
Study wide code lists

### DIFF
--- a/pkg/db/study/db.go
+++ b/pkg/db/study/db.go
@@ -24,6 +24,7 @@ const (
 	COLLECTION_NAME_SUFFIX_FILES                  = "participantFiles"
 	COLLECTION_NAME_SUFFIX_RESEARCHER_MESSAGES    = "researcherMessages"
 	COLLECTION_NAME_TASK_QUEUE                    = "taskQueue"
+	COLLECTION_NAME_STUDY_CODE_LISTS              = "studyCodeLists"
 )
 
 const (
@@ -125,6 +126,10 @@ func (dbService *StudyDBService) collectionResearcherMessages(instanceID string,
 	return dbService.DBClient.Database(dbService.getDBName(instanceID)).Collection(studyKey + "_" + COLLECTION_NAME_SUFFIX_RESEARCHER_MESSAGES)
 }
 
+func (dbService *StudyDBService) collectionStudyCodeLists(instanceID string) *mongo.Collection {
+	return dbService.DBClient.Database(dbService.getDBName(instanceID)).Collection(COLLECTION_NAME_STUDY_CODE_LISTS)
+}
+
 func (dbService *StudyDBService) getContext() (ctx context.Context, cancel context.CancelFunc) {
 	return context.WithTimeout(context.Background(), time.Duration(dbService.timeout)*time.Second)
 }
@@ -177,6 +182,12 @@ func (dbService *StudyDBService) ensureIndexes() error {
 		err = dbService.CreateIndexForStudyRulesCollection(instanceID)
 		if err != nil {
 			slog.Error("Error creating index for studyRules: ", slog.String("error", err.Error()))
+		}
+
+		// index on studyCodeLists
+		err = dbService.CreateIndexForStudyCodeListsCollection(instanceID)
+		if err != nil {
+			slog.Error("Error creating index for studyCodeLists: ", slog.String("error", err.Error()))
 		}
 
 		for _, study := range studies {

--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -1,0 +1,121 @@
+package study
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	studytypes "github.com/case-framework/case-backend/pkg/study/types"
+)
+
+func (dbService *StudyDBService) CreateIndexForStudyCodeListsCollection(instanceID string) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	collection := dbService.collectionStudyCodeLists(instanceID)
+	indexes := []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "studyKey", Value: 1},
+				{Key: "listKey", Value: 1},
+				{Key: "code", Value: 1},
+			},
+			Options: options.Index().SetUnique(true),
+		},
+	}
+	_, err := collection.Indexes().CreateMany(ctx, indexes)
+	return err
+}
+
+func (dbService *StudyDBService) AddStudyCodeListEntry(instanceID string, studyKey string, listKey string, code string) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	entry := studytypes.StudyCodeListEntry{
+		StudyKey: studyKey,
+		ListKey:  listKey,
+		Code:     code,
+		AddedAt:  time.Now(),
+	}
+
+	_, err := dbService.collectionStudyCodeLists(instanceID).InsertOne(ctx, entry)
+	return err
+}
+
+func (dbService *StudyDBService) GetUniqueStudyCodeListKeysForStudy(instanceID string, studyKey string) ([]string, error) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	var listKeys []string
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{"studyKey": studyKey}}},
+		{{Key: "$group", Value: bson.M{"_id": "$listKey"}}},
+	}
+
+	cursor, err := dbService.collectionStudyCodeLists(instanceID).Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []struct {
+		ListKey string `bson:"_id"`
+	}
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, err
+	}
+
+	for _, r := range results {
+		listKeys = append(listKeys, r.ListKey)
+	}
+	return listKeys, nil
+}
+
+func (dbService *StudyDBService) GetStudyCodeListEntries(instanceID string, studyKey string, listKey string) ([]studytypes.StudyCodeListEntry, error) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	filter := bson.M{
+		"studyKey": studyKey,
+		"listKey":  listKey,
+	}
+
+	var entries []studytypes.StudyCodeListEntry
+	cursor, err := dbService.collectionStudyCodeLists(instanceID).Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	err = cursor.All(ctx, &entries)
+	return entries, err
+}
+
+func (dbService *StudyDBService) StudyCodeListEntryExists(instanceID string, studyKey string, listKey string, code string) (bool, error) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	filter := bson.M{
+		"studyKey": studyKey,
+		"listKey":  listKey,
+		"code":     code,
+	}
+
+	count, err := dbService.collectionStudyCodeLists(instanceID).CountDocuments(ctx, filter)
+	return count > 0, err
+}
+
+func (dbService *StudyDBService) DeleteStudyCodeListEntry(instanceID string, studyKey string, listKey string, code string) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	filter := bson.M{
+		"studyKey": studyKey,
+		"listKey":  listKey,
+		"code":     code,
+	}
+
+	_, err := dbService.collectionStudyCodeLists(instanceID).DeleteOne(ctx, filter)
+	return err
+}

--- a/pkg/permission-checker/constants.go
+++ b/pkg/permission-checker/constants.go
@@ -29,6 +29,7 @@ const (
 	ACTION_UPDATE_STUDY_RULES                = "update-study-rules"
 	ACTION_RUN_STUDY_ACTION                  = "run-study-action"
 	ACTION_DELETE_STUDY                      = "delete-study"
+	ACTION_MANAGE_STUDY_CODE_LISTS           = "manage-study-code-lists"
 
 	ACTION_MANAGE_STUDY_PERMISSIONS = "manage-study-permissions"
 

--- a/pkg/study/exporter/survey-definition/compToResponseDef.go
+++ b/pkg/study/exporter/survey-definition/compToResponseDef.go
@@ -128,6 +128,14 @@ func mapToResponseDef(rItem *studytypes.ItemComponent, lang string) []ResponseDe
 		responseDef.Label = label
 		responseDef.ResponseType = QUESTION_TYPE_TEXT_INPUT
 		return []ResponseDef{responseDef}
+	case "codeValidator":
+		label, err := getPreviewText(rItem, lang)
+		if err != nil {
+			slog.Debug("label not found for component")
+		}
+		responseDef.Label = label
+		responseDef.ResponseType = QUESTION_TYPE_TEXT_INPUT
+		return []ResponseDef{responseDef}
 	case "consent":
 		label, err := getPreviewText(rItem, lang)
 		if err != nil {

--- a/pkg/study/studyengine/expressions_test.go
+++ b/pkg/study/studyengine/expressions_test.go
@@ -218,6 +218,14 @@ func (db MockStudyDBService) SaveResearcherMessage(instanceID string, studyKey s
 	return nil
 }
 
+func (db MockStudyDBService) StudyCodeListEntryExists(instanceID string, studyKey string, listKey string, code string) (bool, error) {
+	return false, nil
+}
+
+func (db MockStudyDBService) DeleteStudyCodeListEntry(instanceID string, studyKey string, listKey string, code string) error {
+	return nil
+}
+
 func TestEvalCheckConditionForOldResponses(t *testing.T) {
 
 	testResponses := []studyTypes.SurveyResponse{

--- a/pkg/study/studyengine/types.go
+++ b/pkg/study/studyengine/types.go
@@ -36,6 +36,8 @@ type StudyDBService interface {
 	GetResponses(instanceID string, studyKey string, filter bson.M, sort bson.M, page int64, limit int64) (responses []studyTypes.SurveyResponse, paginationInfo *studyDB.PaginationInfos, err error)
 	DeleteConfidentialResponses(instanceID string, studyKey string, participantID string, key string) (count int64, err error)
 	SaveResearcherMessage(instanceID string, studyKey string, message studyTypes.StudyMessage) error
+	StudyCodeListEntryExists(instanceID string, studyKey string, listKey string, code string) (bool, error)
+	DeleteStudyCodeListEntry(instanceID string, studyKey string, listKey string, code string) error
 }
 
 type ActionData struct {

--- a/pkg/study/types/study-code-list.go
+++ b/pkg/study/types/study-code-list.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type StudyCodeListEntry struct {
+	ID       primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
+	StudyKey string             `bson:"studyKey" json:"studyKey"`
+	ListKey  string             `bson:"listKey" json:"listKey"`
+	Code     string             `bson:"code" json:"code"`
+	AddedAt  time.Time          `bson:"addedAt" json:"addedAt"`
+}

--- a/services/participant-api/apihandlers/study-service.go
+++ b/services/participant-api/apihandlers/study-service.go
@@ -25,7 +25,7 @@ func (h *HttpEndpoints) AddStudyServiceAPI(rg *gin.RouterGroup) {
 		studiesGroup.GET("/", h.getStudiesByStatus) // ?status=active&instanceID=test
 		studiesGroup.GET("/:studyKey", h.getStudy)
 		studiesGroup.GET("/participating", mw.GetAndValidateParticipantUserJWT(h.tokenSignKey), h.getParticipatingStudies)
-		studiesGroup.GET("/:studyKey/code-lists/has-code", h.studyHasCodeListCode) // ?code=code&listKey=listKey
+		studiesGroup.GET("/:studyKey/code-lists/has-code", h.studyHasCodeListCode) // ?code=code&listKey=listKey?instanceID=test
 	}
 
 	// study events


### PR DESCRIPTION
This pull request introduces functionality for managing study code lists in the study database. This can be used, e.g., to check if a user has an entry code, or a valid id code through a questionnaire.

### Database Enhancements:
* Added a new constant `COLLECTION_NAME_STUDY_CODE_LISTS` to define the collection name for study code lists.
* Created the `collectionStudyCodeLists` function to access the study code lists collection.
* Implemented the `CreateIndexForStudyCodeListsCollection` function to create indexes on the study code lists collection.
  * **In order to guarantee unique codes per study code list, run the index creation method for the study DB or create the index manually (studyKey, listKey, code, with option unique)**

### New Study Code List Functions:
* Added functions to add, retrieve, and delete study code list entries, such as `AddStudyCodeListEntry`, `GetUniqueStudyCodeListKeysForStudy`, `GetStudyCodeListEntries`, `StudyCodeListEntryExists`, and `DeleteStudyCodeListEntry`.

### API Enhancements:
* Introduced new endpoints for managing study code lists, including adding, retrieving, and deleting entries. [[1]](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4R318-R368) [[2]](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4R1543-R1656)
* Added a new endpoint to check if a code exists in a study code list. [[1]](diffhunk://#diff-98a1061aeb6f8a1aa2c5ff24252d4de5085d8358f661cdacf0cba99da36eab80R28) [[2]](diffhunk://#diff-98a1061aeb6f8a1aa2c5ff24252d4de5085d8358f661cdacf0cba99da36eab80R196-R229)

### Permission Updates:
* Added a new action `ACTION_MANAGE_STUDY_CODE_LISTS` to the permissions constants to manage study code lists.

### Study Engine Enhancements:
* Added support for a new action `REMOVE_STUDY_CODE` and expression `isStudyCodePresent` to handle study code list entries within the study engine. [[1]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783R73-R74) [[2]](diffhunk://#diff-016090a23f0a180705062387f40b3b376fc78cbed582903cfc30f5fbac2d3f2fR47-R49) [[3]](diffhunk://#diff-016090a23f0a180705062387f40b3b376fc78cbed582903cfc30f5fbac2d3f2fR241-R274)

These changes collectively enhance the management of study code lists, providing comprehensive CRUD operations and integrating them into the existing study engine and API infrastructure.