### PR TITLE
Participant linking codes

### DIFF
--- a/jobs/messaging/participant-messages.go
+++ b/jobs/messaging/participant-messages.go
@@ -107,6 +107,11 @@ func handleParticipantMessages(wg *sync.WaitGroup) {
 							payload["flags."+k] = v
 						}
 
+						// include linking codes into payload
+						for k, v := range p.LinkingCodes {
+							payload["linkingCodes."+k] = v
+						}
+
 						subject, content, err := emailsending.GenerateEmailContent(template, user.Account.PreferredLanguage, payload)
 						if err != nil {
 							counters.IncreaseCounter(false)

--- a/pkg/study/participant-data.go
+++ b/pkg/study/participant-data.go
@@ -473,6 +473,38 @@ func resolvePrefillRules(instanceID string, studyKey string, participantID strin
 	return prefills, nil
 }
 
+func GetLinkingCode(instanceID string, studyKey string, profileID string, key string) (value string, err error) {
+	study, err := getStudyIfActive(instanceID, studyKey)
+	if err != nil {
+		slog.Error("error getting study", slog.String("error", err.Error()))
+		return
+	}
+
+	participantID, _, err := ComputeParticipantIDs(study, profileID)
+	if err != nil {
+		slog.Error("Error computing participant IDs", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("error", err.Error()))
+		return
+	}
+
+	pState, err := studyDBService.GetParticipantByID(instanceID, studyKey, participantID)
+	if err != nil {
+		slog.Debug("Error getting participant state", slog.String("error", err.Error()))
+		return
+	}
+
+	if pState.LinkingCodes == nil {
+		slog.Debug("no linking codes found for participant", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("participantID", participantID))
+		return
+	}
+	value, ok := pState.LinkingCodes[key]
+	if !ok {
+		slog.Debug("linking code for key not found", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("participantID", participantID), slog.String("key", key))
+		return
+	}
+
+	return value, nil
+}
+
 func GetSubmissionHistory(instanceID string, studyKey string, profileIDs []string, limit int64) (submissionHistory SubmissionHistory, err error) {
 	study, err := getStudyIfActive(instanceID, studyKey)
 	if err != nil {

--- a/pkg/study/studyengine/expressions.go
+++ b/pkg/study/studyengine/expressions.go
@@ -75,6 +75,10 @@ func ExpressionEval(expression studyTypes.Expression, evalCtx EvalContext) (val 
 		val, err = evalCtx.hasParticipantFlagKey(expression, false)
 	case "getParticipantFlagValue":
 		val, err = evalCtx.getParticipantFlagValue(expression, false)
+	case "hasLinkingCode":
+		val, err = evalCtx.hasLinkingCode(expression, false)
+	case "getLinkingCodeValue":
+		val, err = evalCtx.getLinkingCode(expression, false)
 	case "getLastSubmissionDate":
 		val, err = evalCtx.getLastSubmissionDate(expression, false)
 	case "lastSubmissionDateOlderThan":
@@ -100,6 +104,10 @@ func ExpressionEval(expression studyTypes.Expression, evalCtx EvalContext) (val 
 		val, err = evalCtx.hasParticipantFlagKey(expression, true)
 	case "incomingState:getParticipantFlagValue":
 		val, err = evalCtx.getParticipantFlagValue(expression, true)
+	case "incomingState:hasLinkingCode":
+		val, err = evalCtx.hasLinkingCode(expression, true)
+	case "incomingState:getLinkingCodeValue":
+		val, err = evalCtx.getLinkingCode(expression, true)
 	case "incomingState:getLastSubmissionDate":
 		val, err = evalCtx.getLastSubmissionDate(expression, true)
 	case "incomingState:lastSubmissionDateOlderThan":
@@ -689,6 +697,64 @@ func (ctx EvalContext) hasParticipantFlag(exp studyTypes.Expression, withIncomin
 		return false, nil
 	}
 	return true, nil
+}
+
+func (ctx EvalContext) hasLinkingCode(exp studyTypes.Expression, withIncomingParticipantState bool) (val bool, err error) {
+	pState := ctx.ParticipantState
+	if withIncomingParticipantState {
+		pState = ctx.Event.MergeWithParticipant
+	}
+	if len(exp.Data) != 1 {
+		return val, errors.New("unexpected numbers of arguments")
+	}
+
+	if exp.Data[0].IsNumber() {
+		return val, errors.New("unexpected argument types")
+	}
+
+	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	if err != nil {
+		return val, err
+	}
+	arg1Val, ok := arg1.(string)
+	if !ok {
+		return val, errors.New("could not cast argument 1")
+	}
+
+	_, ok = pState.LinkingCodes[arg1Val]
+	if !ok {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (ctx EvalContext) getLinkingCode(exp studyTypes.Expression, withIncomingParticipantState bool) (val string, err error) {
+	pState := ctx.ParticipantState
+	if withIncomingParticipantState {
+		pState = ctx.Event.MergeWithParticipant
+	}
+	if len(exp.Data) != 1 {
+		return val, errors.New("unexpected numbers of arguments")
+	}
+
+	if exp.Data[0].IsNumber() {
+		return val, errors.New("unexpected argument types")
+	}
+
+	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	if err != nil {
+		return val, err
+	}
+	arg1Val, ok := arg1.(string)
+	if !ok {
+		return val, errors.New("could not cast argument 1")
+	}
+
+	res, ok := pState.LinkingCodes[arg1Val]
+	if !ok {
+		return "", nil
+	}
+	return res, nil
 }
 
 func (ctx EvalContext) getLastSubmissionDate(exp studyTypes.Expression, withIncomingParticipantState bool) (val float64, err error) {

--- a/pkg/study/types/participant.go
+++ b/pkg/study/types/participant.go
@@ -17,6 +17,7 @@ type Participant struct {
 	EnteredAt           int64                `bson:"enteredAt" json:"enteredAt"`
 	StudyStatus         string               `bson:"studyStatus" json:"studyStatus"` // shows if participant is active in the study - possible values: "active", "temporary", "exited". Other values are possible and are handled like "exited" on the server.
 	Flags               map[string]string    `bson:"flags" json:"flags"`
+	LinkingCodes        map[string]string    `bson:"linkingCodes" json:"linkingCodes"`
 	AssignedSurveys     []AssignedSurvey     `bson:"assignedSurveys" json:"assignedSurveys"`
 	LastSubmissions     map[string]int64     `bson:"lastSubmission" json:"lastSubmissions"` // surveyKey with timestamp
 	Messages            []ParticipantMessage `bson:"messages" json:"messages"`


### PR DESCRIPTION
This pull request introduces a new feature to handle linking codes for participants in a study. The changes include adding functions to set, delete, and retrieve linking codes, as well as updating the participant structure to include linking codes.

### Linking Codes Feature:

* [`jobs/messaging/participant-messages.go`](diffhunk://#diff-be928a8c7070f8c14eb1d7e07dcb7392b0174545a3e3d58b66d4529538af03a0R110-R114): Added logic to include linking codes in the payload when handling participant messages.
* [`pkg/study/participant-data.go`](diffhunk://#diff-7c6e7b6c2f80ffb4d32e61e256994417453cf337390adf0012dac6ef4d1c842fR476-R507): Introduced the `GetLinkingCode` function to retrieve linking codes for a participant.
* [`pkg/study/studyengine/actions.go`](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783R43-R46): Added `setLinkingCodeAction` and `deleteLinkingCodeAction` functions to handle setting and deleting linking codes. [[1]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783R43-R46) [[2]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783R292-R364)
* [`pkg/study/studyengine/expressions.go`](diffhunk://#diff-016090a23f0a180705062387f40b3b376fc78cbed582903cfc30f5fbac2d3f2fR78-R81): Added expressions `hasLinkingCode` and `getLinkingCodeValue` to evaluate linking codes in the study engine. [[1]](diffhunk://#diff-016090a23f0a180705062387f40b3b376fc78cbed582903cfc30f5fbac2d3f2fR78-R81) [[2]](diffhunk://#diff-016090a23f0a180705062387f40b3b376fc78cbed582903cfc30f5fbac2d3f2fR107-R110) [[3]](diffhunk://#diff-016090a23f0a180705062387f40b3b376fc78cbed582903cfc30f5fbac2d3f2fR702-R759)
* [`pkg/study/types/participant.go`](diffhunk://#diff-83eaf5c8255f68d3d2fa310d994e11bf4695047403dc9ceebd3e992a0ace7eedR20): Updated the `Participant` struct to include a `LinkingCodes` field.

### API Enhancements:

* [`services/participant-api/apihandlers/study-service.go`](diffhunk://#diff-98a1061aeb6f8a1aa2c5ff24252d4de5085d8358f661cdacf0cba99da36eab80R55-R56): Added an endpoint to get linking codes (`/linking-code`). [[1]](diffhunk://#diff-98a1061aeb6f8a1aa2c5ff24252d4de5085d8358f661cdacf0cba99da36eab80R55-R56) [[2]](diffhunk://#diff-98a1061aeb6f8a1aa2c5ff24252d4de5085d8358f661cdacf0cba99da36eab80R595-R626)