### PR TITLE
feat (participant-api): add toggle for weekly subscription in contact preferences

### DIFF
--- a/services/participant-api/apihandlers/user-management.go
+++ b/services/participant-api/apihandlers/user-management.go
@@ -600,7 +600,8 @@ func (h *HttpEndpoints) updateContactPreferences(c *gin.Context) {
 	token := c.MustGet("validatedToken").(*jwthandling.ParticipantUserClaims)
 
 	var req struct {
-		SubscribedToNewsletter bool `json:"subscribedToNewsletter"`
+		SubscribedToNewsletter   bool `json:"subscribedToNewsletter"`
+		ToggleWeeklySubscription bool `json:"toggleWeeklySubscription"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -617,6 +618,10 @@ func (h *HttpEndpoints) updateContactPreferences(c *gin.Context) {
 	}
 
 	user.ContactPreferences.SubscribedToNewsletter = req.SubscribedToNewsletter
+
+	if req.ToggleWeeklySubscription {
+		user.ContactPreferences.SubscribedToWeekly = !user.ContactPreferences.SubscribedToWeekly
+	}
 
 	_, err = h.userDBConn.ReplaceUser(token.InstanceID, user)
 	if err != nil {


### PR DESCRIPTION
This pull request includes an update to the `updateContactPreferences` function in the `services/participant-api/apihandlers/user-management.go` file. The main change is the addition of a new field to handle the weekly subscription toggle.

Changes to update contact preferences:

* Added a new field `ToggleWeeklySubscription` to the request struct to handle toggling the weekly subscription.
* Implemented logic to toggle the weekly subscription status based on the new `ToggleWeeklySubscription` field.