### PR TITLE
Daily exporter features

### DIFF
--- a/jobs/study-daily-data-export/confidential-resp-exporter.go
+++ b/jobs/study-daily-data-export/confidential-resp-exporter.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
+	studyutils "github.com/case-framework/case-backend/pkg/study/utils"
+)
+
+type ConfidentialResponsesExportEntry struct {
+	ParticipantID string
+	EntryID       string
+	ResponseKey   string
+	Value         string
+}
+
+func runConfidentialResponsesExportsForTask(rExpTask ConfidentialResponsesExportTask) {
+	// ensure there is a folder path for the source (export_path/instance_id/study_key)
+	relativeFolderPath := path.Join(rExpTask.InstanceID, rExpTask.StudyKey)
+	exportFolderPathForTask := path.Join(conf.ExportPath, relativeFolderPath)
+	if _, err := os.Stat(exportFolderPathForTask); os.IsNotExist(err) {
+		// create folder
+		err = os.MkdirAll(exportFolderPathForTask, os.ModePerm)
+		if err != nil {
+			slog.Error("Error creating export path", slog.String("error", err.Error()))
+			return
+		}
+		slog.Info("Created export path", slog.String("path", exportFolderPathForTask))
+	}
+
+	// get study
+	study, err := studyDBService.GetStudy(rExpTask.InstanceID, rExpTask.StudyKey)
+	if err != nil {
+		slog.Error("failed to get study", slog.String("error", err.Error()))
+		return
+	}
+
+	studySecretKey := study.SecretKey
+	idMappingMethod := study.Configs.IdMappingMethod
+	globalSecret := rExpTask.StudyGlobalSecret
+
+	// export to file (CSV or JSON)
+	results := []ConfidentialResponsesExportEntry{}
+
+	if err := studyDBService.FindAndExecuteOnConfidentialResponses(
+		context.Background(),
+		rExpTask.InstanceID,
+		rExpTask.StudyKey,
+		false,
+		func(r studyTypes.SurveyResponse, args ...interface{}) error {
+			// compute real participantID (confidentialID -> profileID -> participantID)
+			confidentialID := r.ParticipantID
+			profileID, err := studyDBService.GetProfileIDFromConfidentialID(rExpTask.InstanceID, confidentialID, rExpTask.StudyKey)
+			if err != nil {
+				slog.Error("can't find profileID based on confidentialID, you may need to generate profileID lookup", slog.String("error", err.Error()))
+				return nil
+			}
+
+			pID, err := studyutils.ProfileIDtoParticipantID(profileID, globalSecret, studySecretKey, idMappingMethod)
+			if err != nil {
+				slog.Error("failed to compute participantID", slog.String("error", err.Error()))
+				return nil
+			}
+
+			results = append(results, confidentialResponseExport(r, pID, rExpTask.RespKeyFilter)...)
+			return nil
+		},
+	); err != nil {
+		slog.Error("failed to execute on confidential responses", slog.String("error", err.Error()))
+		return
+	}
+
+	// write to file (CSV or JSON)
+	if rExpTask.ExportFormat == "csv" {
+		err = writeCSV(results, rExpTask.Name, exportFolderPathForTask)
+	} else {
+		err = writeJSON(results, rExpTask.Name, exportFolderPathForTask)
+	}
+	if err != nil {
+		slog.Error("failed to write to file", slog.String("error", err.Error()))
+		return
+	}
+}
+
+func confidentialResponsesExportFileName(name string, exportFormat string) string {
+	parts := []string{
+		time.Now().Format("2006-01-02"),
+		"confidential-responses",
+		name,
+		exportFormat,
+	}
+	return strings.Join(parts, "##") + "." + exportFormat
+}
+
+func writeCSV(results []ConfidentialResponsesExportEntry, name string, exportFolderPathForTask string) error {
+	filename := confidentialResponsesExportFileName(name, "csv")
+	file, err := os.Create(filepath.Join(exportFolderPathForTask, filename))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	// write header
+	header := []string{"participantID", "entryID", "responseKey", "value"}
+	if err := writer.Write(header); err != nil {
+		return err
+	}
+
+	for _, r := range results {
+		row := []string{r.ParticipantID, r.EntryID, r.ResponseKey, r.Value}
+		if err := writer.Write(row); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeJSON(results []ConfidentialResponsesExportEntry, name string, exportFolderPathForTask string) error {
+	filename := confidentialResponsesExportFileName(name, "json")
+	file, err := os.Create(filepath.Join(exportFolderPathForTask, filename))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+
+	err = encoder.Encode(results)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseSlots(respItem *studyTypes.ResponseItem, slotKey string) map[string]string {
+	parsedResp := map[string]string{}
+	if respItem == nil {
+		return parsedResp
+	}
+
+	currentSlotKey := slotKey + "." + respItem.Key
+	if strings.HasSuffix(slotKey, "-") {
+		currentSlotKey = slotKey + respItem.Key
+	}
+
+	if len(respItem.Items) == 0 {
+		parsedResp[currentSlotKey] = respItem.Value
+		return parsedResp
+	}
+
+	for _, subItem := range respItem.Items {
+		r := parseSlots(subItem, currentSlotKey)
+		for k, v := range r {
+			parsedResp[k] = v
+		}
+	}
+	return parsedResp
+}
+
+func confidentialResponseExport(resp studyTypes.SurveyResponse, realPID string, respKeyFilter []string) []ConfidentialResponsesExportEntry {
+	parsedResp := []ConfidentialResponsesExportEntry{}
+
+	for _, r := range resp.Responses {
+		slotKey := r.Key + "-"
+
+		slots := parseSlots(r.Response, slotKey)
+		for k, v := range slots {
+			if len(respKeyFilter) > 0 && !stringInSlice(k, respKeyFilter) {
+				continue
+			}
+			parsedResp = append(parsedResp, ConfidentialResponsesExportEntry{
+				ParticipantID: realPID,
+				EntryID:       resp.ID.Hex(),
+				ResponseKey:   k,
+				Value:         v,
+			})
+		}
+	}
+
+	return parsedResp
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanUpConfidentialResponsesExports() {
+	// clean up all existing confidential responses exports
+	if err := filepath.Walk(conf.ExportPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		// Parse date from filename (assuming format YYYY-MM-DD##responses##..##..)
+		basename := filepath.Base(path)
+		parts := strings.Split(basename, "##")
+		if len(parts) < 2 {
+			return nil
+		}
+
+		if parts[1] != "confidential-responses" {
+			return nil
+		}
+
+		// remove file
+		err = os.Remove(path)
+		if err != nil {
+			slog.Error("Failed to remove old confidential responses export", slog.String("path", path), slog.String("error", err.Error()))
+		}
+
+		return nil
+	}); err != nil {
+		slog.Error("Error cleaning up old confidential responses exports", slog.String("error", err.Error()))
+	}
+}

--- a/jobs/study-daily-data-export/init.go
+++ b/jobs/study-daily-data-export/init.go
@@ -40,12 +40,16 @@ type config struct {
 		StudyDB db.DBConfigYaml `json:"study_db" yaml:"study_db"`
 	} `json:"db_configs" yaml:"db_configs"`
 
+	ExportPath string `json:"export_path" yaml:"export_path"`
+
 	ResponseExports struct {
-		ExportPath    string               `json:"export_path" yaml:"export_path"`
 		RetentionDays int                  `json:"retention_days" yaml:"retention_days"`
 		OverrideOld   bool                 `json:"override_old" yaml:"override_old"`
 		ExportTasks   []ResponseExportTask `json:"export_tasks" yaml:"export_tasks"`
 	} `json:"response_exports" yaml:"response_exports"`
+
+	ConfidentialResponsesExports struct {
+	}
 }
 
 var conf config
@@ -91,20 +95,20 @@ func init() {
 		panic(err)
 	}
 
-	if conf.ResponseExports.ExportPath == "" {
+	if conf.ExportPath == "" {
 		err := fmt.Errorf("export path must be set to define where to store the export files")
 		slog.Error("Error reading config", slog.String("error", err.Error()))
 		panic(err)
 	}
 
-	if _, err := os.Stat(conf.ResponseExports.ExportPath); os.IsNotExist(err) {
+	if _, err := os.Stat(conf.ExportPath); os.IsNotExist(err) {
 		// create folder
-		err = os.MkdirAll(conf.ResponseExports.ExportPath, os.ModePerm)
+		err = os.MkdirAll(conf.ExportPath, os.ModePerm)
 		if err != nil {
 			slog.Error("Error creating export path", slog.String("error", err.Error()))
 			panic(err)
 		}
-		slog.Info("Created export path", slog.String("path", conf.ResponseExports.ExportPath))
+		slog.Info("Created export path", slog.String("path", conf.ExportPath))
 	}
 }
 

--- a/jobs/study-daily-data-export/init.go
+++ b/jobs/study-daily-data-export/init.go
@@ -21,6 +21,16 @@ const (
 	ENV_STUDY_DB_PASSWORD = "STUDY_DB_PASSWORD"
 )
 
+type ResponseExportTask struct {
+	InstanceID   string   `json:"instance_id" yaml:"instance_id"`
+	StudyKey     string   `json:"study_key" yaml:"study_key"`
+	SurveyKeys   []string `json:"survey_keys" yaml:"survey_keys"`
+	ExtraCtxCols []string `json:"extra_context_columns" yaml:"extra_context_columns"`
+	ExportFormat string   `json:"export_format" yaml:"export_format"`
+	Separator    string   `json:"separator" yaml:"separator"`
+	ShortKeys    bool     `json:"short_keys" yaml:"short_keys"`
+}
+
 type config struct {
 	// Logging configs
 	Logging utils.LoggerConfig `json:"logging" yaml:"logging"`
@@ -31,18 +41,10 @@ type config struct {
 	} `json:"db_configs" yaml:"db_configs"`
 
 	ResponseExports struct {
-		ExportPath    string `json:"export_path" yaml:"export_path"`
-		RetentionDays int    `json:"retention_days" yaml:"retention_days"`
-		OverrideOld   bool   `json:"override_old" yaml:"override_old"`
-		ExportFormat  string `json:"export_format" yaml:"export_format"`
-		Separator     string `json:"separator" yaml:"separator"`
-		ShortKeys     bool   `json:"short_keys" yaml:"short_keys"`
-		Sources       []struct {
-			InstanceID   string   `json:"instance_id" yaml:"instance_id"`
-			StudyKey     string   `json:"study_key" yaml:"study_key"`
-			SurveyKeys   []string `json:"survey_keys" yaml:"survey_keys"`
-			ExtraCtxCols []string `json:"extra_context_columns" yaml:"extra_context_columns"`
-		} `json:"sources" yaml:"sources"`
+		ExportPath    string               `json:"export_path" yaml:"export_path"`
+		RetentionDays int                  `json:"retention_days" yaml:"retention_days"`
+		OverrideOld   bool                 `json:"override_old" yaml:"override_old"`
+		ExportTasks   []ResponseExportTask `json:"export_tasks" yaml:"export_tasks"`
 	} `json:"response_exports" yaml:"response_exports"`
 }
 
@@ -132,7 +134,7 @@ func initDBs() {
 
 func getInstanceIDs() []string {
 	instanceIDs := []string{}
-	for _, source := range conf.ResponseExports.Sources {
+	for _, source := range conf.ResponseExports.ExportTasks {
 		instanceIDs = append(instanceIDs, source.InstanceID)
 	}
 	return instanceIDs

--- a/jobs/study-daily-data-export/init.go
+++ b/jobs/study-daily-data-export/init.go
@@ -31,6 +31,13 @@ type ResponseExportTask struct {
 	ShortKeys    bool     `json:"short_keys" yaml:"short_keys"`
 }
 
+type ConfidentialResponsesExportTask struct {
+	InstanceID    string `json:"instance_id" yaml:"instance_id"`
+	StudyKey      string `json:"study_key" yaml:"study_key"`
+	Name          string `json:"name" yaml:"name"`                       // optional name for the export file (used as "survey_key")
+	RespKeyFilter string `json:"resp_key_filter" yaml:"resp_key_filter"` // optional filter for response keys to inlcude only these
+}
+
 type config struct {
 	// Logging configs
 	Logging utils.LoggerConfig `json:"logging" yaml:"logging"`
@@ -49,7 +56,8 @@ type config struct {
 	} `json:"response_exports" yaml:"response_exports"`
 
 	ConfidentialResponsesExports struct {
-	}
+		ExportTasks []ConfidentialResponsesExportTask `json:"export_tasks" yaml:"export_tasks"`
+	} `json:"conf_resp_exports" yaml:"conf_resp_exports"`
 }
 
 var conf config

--- a/jobs/study-daily-data-export/init.go
+++ b/jobs/study-daily-data-export/init.go
@@ -58,7 +58,8 @@ type config struct {
 	} `json:"response_exports" yaml:"response_exports"`
 
 	ConfidentialResponsesExports struct {
-		ExportTasks []ConfidentialResponsesExportTask `json:"export_tasks" yaml:"export_tasks"`
+		PreservePreviousFiles bool                              `json:"preserve_previous_files" yaml:"preserve_previous_files"`
+		ExportTasks           []ConfidentialResponsesExportTask `json:"export_tasks" yaml:"export_tasks"`
 	} `json:"conf_resp_exports" yaml:"conf_resp_exports"`
 }
 

--- a/jobs/study-daily-data-export/init.go
+++ b/jobs/study-daily-data-export/init.go
@@ -32,10 +32,12 @@ type ResponseExportTask struct {
 }
 
 type ConfidentialResponsesExportTask struct {
-	InstanceID    string `json:"instance_id" yaml:"instance_id"`
-	StudyKey      string `json:"study_key" yaml:"study_key"`
-	Name          string `json:"name" yaml:"name"`                       // optional name for the export file (used as "survey_key")
-	RespKeyFilter string `json:"resp_key_filter" yaml:"resp_key_filter"` // optional filter for response keys to inlcude only these
+	InstanceID        string   `json:"instance_id" yaml:"instance_id"`
+	StudyKey          string   `json:"study_key" yaml:"study_key"`
+	StudyGlobalSecret string   `json:"study_global_secret" yaml:"study_global_secret"`
+	Name              string   `json:"name" yaml:"name"`                       // optional name for the export file (used as "survey_key")
+	RespKeyFilter     []string `json:"resp_key_filter" yaml:"resp_key_filter"` // optional filter for response keys to inlcude only these
+	ExportFormat      string   `json:"export_format" yaml:"export_format"`     // csv or json
 }
 
 type config struct {

--- a/jobs/study-daily-data-export/main.go
+++ b/jobs/study-daily-data-export/main.go
@@ -33,7 +33,7 @@ func main() {
 func runResponseExportsForTask(rExpTask ResponseExportTask) {
 	// ensure there is a folder path for the source (export_path/instance_id/study_key)
 	relativeFolderPath := path.Join(rExpTask.InstanceID, rExpTask.StudyKey)
-	exportFolderPathForSource := path.Join(conf.ResponseExports.ExportPath, relativeFolderPath)
+	exportFolderPathForSource := path.Join(conf.ExportPath, relativeFolderPath)
 	if _, err := os.Stat(exportFolderPathForSource); os.IsNotExist(err) {
 		// create folder
 		err = os.MkdirAll(exportFolderPathForSource, os.ModePerm)

--- a/jobs/study-daily-data-export/main.go
+++ b/jobs/study-daily-data-export/main.go
@@ -3,17 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 	"time"
-
-	studyDB "github.com/case-framework/case-backend/pkg/db/study"
-	surveydefinition "github.com/case-framework/case-backend/pkg/study/exporter/survey-definition"
-	surveyresponses "github.com/case-framework/case-backend/pkg/study/exporter/survey-responses"
-	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 func main() {
@@ -21,202 +11,18 @@ func main() {
 	start := time.Now()
 
 	for _, rExpTask := range conf.ResponseExports.ExportTasks {
+		slog.Info("Running response export task", slog.String("instanceID", rExpTask.InstanceID), slog.String("studyKey", rExpTask.StudyKey))
 		runResponseExportsForTask(rExpTask)
+	}
+
+	cleanUpConfidentialResponsesExports()
+	for _, rExpTask := range conf.ConfidentialResponsesExports.ExportTasks {
+		slog.Info("Running confidential responses export task", slog.String("instanceID", rExpTask.InstanceID), slog.String("studyKey", rExpTask.StudyKey), slog.String("name", rExpTask.Name))
+		runConfidentialResponsesExportsForTask(rExpTask)
 	}
 
 	if err := studyDBService.DBClient.Disconnect(context.Background()); err != nil {
 		slog.Error("Error closing DB connection", slog.String("error", err.Error()))
 	}
 	slog.Info("Study daily data export job completed", slog.String("duration", time.Since(start).String()))
-}
-
-func runResponseExportsForTask(rExpTask ResponseExportTask) {
-	// ensure there is a folder path for the source (export_path/instance_id/study_key)
-	relativeFolderPath := path.Join(rExpTask.InstanceID, rExpTask.StudyKey)
-	exportFolderPathForSource := path.Join(conf.ExportPath, relativeFolderPath)
-	if _, err := os.Stat(exportFolderPathForSource); os.IsNotExist(err) {
-		// create folder
-		err = os.MkdirAll(exportFolderPathForSource, os.ModePerm)
-		if err != nil {
-			slog.Error("Error creating export path", slog.String("error", err.Error()))
-			return
-		}
-		slog.Info("Created export path", slog.String("path", exportFolderPathForSource))
-	}
-
-	// remove old files (keep only the last retention_days, but at least yesterday and today)
-	if err := cleanUpForSource(exportFolderPathForSource); err != nil {
-		slog.Error("Error cleaning up old files", slog.String("error", err.Error()))
-	}
-
-	for _, surveyKey := range rExpTask.SurveyKeys {
-		parser, err := initResponseParser(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ShortKeys, rExpTask.Separator)
-		if err != nil {
-			continue
-		}
-
-		if conf.ResponseExports.OverrideOld {
-			for i := 0; i < conf.ResponseExports.RetentionDays-1; i++ {
-				targetDate := time.Now().Add(
-					time.Duration(-(conf.ResponseExports.RetentionDays - i)) * time.Hour * 24,
-				)
-				generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForSource, parser)
-			}
-		}
-
-		// yesterday
-		targetDate := time.Now().Add(
-			time.Duration(-1 * time.Hour * 24),
-		)
-		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForSource, parser)
-
-		// today
-		targetDate = time.Now()
-		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForSource, parser)
-	}
-}
-
-func initResponseParser(instanceID string, studyKey string, surveyKey string, shortKeys bool, separator string) (parser *surveyresponses.ResponseParser, err error) {
-	surveyVersions, err := surveydefinition.PrepareSurveyInfosFromDB(
-		studyDBService,
-		instanceID,
-		studyKey,
-		surveyKey,
-		&surveydefinition.ExtractOptions{
-			UseLabelLang: "",
-			IncludeItems: nil,
-			ExcludeItems: nil,
-		},
-	)
-	if err != nil {
-		slog.Error("failed to get survey versions", slog.String("error", err.Error()))
-		return
-	}
-	extraCols := conf.ResponseExports.ExportTasks[0].ExtraCtxCols
-	parser, err = surveyresponses.NewResponseParser(
-		surveyKey,
-		surveyVersions,
-		shortKeys,
-		nil,
-		separator,
-		&extraCols,
-	)
-	if err != nil {
-		slog.Error("failed to create response parser", slog.String("error", err.Error()))
-		return
-	}
-	return
-}
-
-func generateExportForSurveyForTargetDate(instanceID string, studyKey string, surveyKey string, format string, targetDate time.Time, exportPath string, parser *surveyresponses.ResponseParser) {
-	fileName := responseFileName(targetDate, surveyKey, format)
-	responseFilePath := filepath.Join(exportPath, fileName)
-
-	if fileExists(responseFilePath) {
-		slog.Debug("File already exists, overriding", slog.String("path", responseFilePath))
-	}
-
-	filter := bson.M{
-		"key": surveyKey,
-		"$and": bson.A{
-			bson.M{"arrivedAt": bson.M{"$lte": endOfDay(targetDate).Unix()}},
-			bson.M{"arrivedAt": bson.M{"$gte": startOfDay(targetDate).Unix()}},
-		},
-	}
-	// count responses for target date and survey key --> if 0, skip
-	count, err := studyDBService.GetResponsesCount(instanceID, studyKey, filter)
-	if err != nil {
-		slog.Error("Error getting responses count", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("surveyKey", surveyKey), slog.String("error", err.Error()))
-		return
-	}
-	if count == 0 {
-		slog.Debug("No responses for target date and survey key, skipping", slog.String("targetDate", targetDate.Format("2006-01-02")), slog.String("surveyKey", surveyKey))
-		return
-	}
-
-	file, err := os.Create(responseFilePath)
-	if err != nil {
-		slog.Error("failed to create export file", slog.String("error", err.Error()))
-		return
-	}
-
-	defer file.Close()
-
-	exporter, err := surveyresponses.NewResponseExporter(
-		parser,
-		file,
-		format,
-	)
-	if err != nil {
-		slog.Error("failed to create response exporter", slog.String("error", err.Error()))
-		return
-	}
-
-	err = studyDBService.FindAndExecuteOnResponses(
-		context.Background(),
-		instanceID,
-		studyKey,
-		filter,
-		bson.M{"arrivedAt": 1},
-		false,
-		func(dbService *studyDB.StudyDBService, r studyTypes.SurveyResponse, instanceID, studyKey string, args ...interface{}) error {
-			err := exporter.WriteResponse(&r)
-			if err != nil {
-				return err
-			}
-			return nil
-		},
-		nil,
-	)
-	if err != nil {
-		slog.Error("Error generating response export", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("surveyKey", surveyKey), slog.String("error", err.Error()))
-		return
-	}
-
-	err = exporter.Finish()
-	if err != nil {
-		slog.Error("failed to finish export", slog.String("error", err.Error()))
-		return
-	}
-	slog.Info("Generated response export", slog.String("path", responseFilePath))
-}
-
-func cleanUpForSource(sourceDir string) error {
-	cutoffDate := time.Now().Add(
-		time.Duration(-(conf.ResponseExports.RetentionDays + 1)) * time.Hour * 24,
-	)
-
-	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		// Parse date from filename (assuming format YYYY-MM-DD##responses##..##..)
-		basename := filepath.Base(path)
-		parts := strings.Split(basename, "##")
-		if len(parts) < 1 {
-			return nil
-		}
-		datePart := parts[0]
-		if len(datePart) < 10 {
-			return nil
-		}
-
-		fileDate, err := time.Parse("2006-01-02", datePart)
-		if err != nil {
-			return nil
-		}
-
-		if fileDate.Before(cutoffDate) {
-			if err := os.Remove(path); err != nil {
-				slog.Error("Failed to remove old file", slog.String("path", path), slog.String("error", err.Error()))
-			}
-		}
-
-		return nil
-	})
 }

--- a/jobs/study-daily-data-export/main.go
+++ b/jobs/study-daily-data-export/main.go
@@ -15,7 +15,11 @@ func main() {
 		runResponseExportsForTask(rExpTask)
 	}
 
-	cleanUpConfidentialResponsesExports()
+	if !conf.ConfidentialResponsesExports.PreservePreviousFiles {
+		cleanUpConfidentialResponsesExports()
+	} else {
+		slog.Info("Not cleaning up previous confidential responses exports")
+	}
 	for _, rExpTask := range conf.ConfidentialResponsesExports.ExportTasks {
 		slog.Info("Running confidential responses export task", slog.String("instanceID", rExpTask.InstanceID), slog.String("studyKey", rExpTask.StudyKey), slog.String("name", rExpTask.Name))
 		runConfidentialResponsesExportsForTask(rExpTask)

--- a/jobs/study-daily-data-export/response-exporter.go
+++ b/jobs/study-daily-data-export/response-exporter.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	studyDB "github.com/case-framework/case-backend/pkg/db/study"
+	surveydefinition "github.com/case-framework/case-backend/pkg/study/exporter/survey-definition"
+	surveyresponses "github.com/case-framework/case-backend/pkg/study/exporter/survey-responses"
+	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func runResponseExportsForTask(rExpTask ResponseExportTask) {
+	// ensure there is a folder path for the source (export_path/instance_id/study_key)
+	relativeFolderPath := path.Join(rExpTask.InstanceID, rExpTask.StudyKey)
+	exportFolderPathForTask := path.Join(conf.ExportPath, relativeFolderPath)
+	if _, err := os.Stat(exportFolderPathForTask); os.IsNotExist(err) {
+		// create folder
+		err = os.MkdirAll(exportFolderPathForTask, os.ModePerm)
+		if err != nil {
+			slog.Error("Error creating export path", slog.String("error", err.Error()))
+			return
+		}
+		slog.Info("Created export path", slog.String("path", exportFolderPathForTask))
+	}
+
+	// remove old files (keep only the last retention_days, but at least yesterday and today)
+	if err := cleanUpForSource(exportFolderPathForTask); err != nil {
+		slog.Error("Error cleaning up old files", slog.String("error", err.Error()))
+	}
+
+	for _, surveyKey := range rExpTask.SurveyKeys {
+		parser, err := initResponseParser(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ShortKeys, rExpTask.Separator)
+		if err != nil {
+			continue
+		}
+
+		if conf.ResponseExports.OverrideOld {
+			for i := 0; i < conf.ResponseExports.RetentionDays-1; i++ {
+				targetDate := time.Now().Add(
+					time.Duration(-(conf.ResponseExports.RetentionDays - i)) * time.Hour * 24,
+				)
+				generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser)
+			}
+		}
+
+		// yesterday
+		targetDate := time.Now().Add(
+			time.Duration(-1 * time.Hour * 24),
+		)
+		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser)
+
+		// today
+		targetDate = time.Now()
+		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser)
+	}
+}
+
+func initResponseParser(instanceID string, studyKey string, surveyKey string, shortKeys bool, separator string) (parser *surveyresponses.ResponseParser, err error) {
+	surveyVersions, err := surveydefinition.PrepareSurveyInfosFromDB(
+		studyDBService,
+		instanceID,
+		studyKey,
+		surveyKey,
+		&surveydefinition.ExtractOptions{
+			UseLabelLang: "",
+			IncludeItems: nil,
+			ExcludeItems: nil,
+		},
+	)
+	if err != nil {
+		slog.Error("failed to get survey versions", slog.String("error", err.Error()))
+		return
+	}
+	extraCols := conf.ResponseExports.ExportTasks[0].ExtraCtxCols
+	parser, err = surveyresponses.NewResponseParser(
+		surveyKey,
+		surveyVersions,
+		shortKeys,
+		nil,
+		separator,
+		&extraCols,
+	)
+	if err != nil {
+		slog.Error("failed to create response parser", slog.String("error", err.Error()))
+		return
+	}
+	return
+}
+
+func generateExportForSurveyForTargetDate(instanceID string, studyKey string, surveyKey string, format string, targetDate time.Time, exportPath string, parser *surveyresponses.ResponseParser) {
+	fileName := responseFileName(targetDate, surveyKey, format)
+	responseFilePath := filepath.Join(exportPath, fileName)
+
+	if fileExists(responseFilePath) {
+		slog.Debug("File already exists, overriding", slog.String("path", responseFilePath))
+	}
+
+	filter := bson.M{
+		"key": surveyKey,
+		"$and": bson.A{
+			bson.M{"arrivedAt": bson.M{"$lte": endOfDay(targetDate).Unix()}},
+			bson.M{"arrivedAt": bson.M{"$gte": startOfDay(targetDate).Unix()}},
+		},
+	}
+	// count responses for target date and survey key --> if 0, skip
+	count, err := studyDBService.GetResponsesCount(instanceID, studyKey, filter)
+	if err != nil {
+		slog.Error("Error getting responses count", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("surveyKey", surveyKey), slog.String("error", err.Error()))
+		return
+	}
+	if count == 0 {
+		slog.Debug("No responses for target date and survey key, skipping", slog.String("targetDate", targetDate.Format("2006-01-02")), slog.String("surveyKey", surveyKey))
+		return
+	}
+
+	file, err := os.Create(responseFilePath)
+	if err != nil {
+		slog.Error("failed to create export file", slog.String("error", err.Error()))
+		return
+	}
+
+	defer file.Close()
+
+	exporter, err := surveyresponses.NewResponseExporter(
+		parser,
+		file,
+		format,
+	)
+	if err != nil {
+		slog.Error("failed to create response exporter", slog.String("error", err.Error()))
+		return
+	}
+
+	err = studyDBService.FindAndExecuteOnResponses(
+		context.Background(),
+		instanceID,
+		studyKey,
+		filter,
+		bson.M{"arrivedAt": 1},
+		false,
+		func(dbService *studyDB.StudyDBService, r studyTypes.SurveyResponse, instanceID, studyKey string, args ...interface{}) error {
+			err := exporter.WriteResponse(&r)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		nil,
+	)
+	if err != nil {
+		slog.Error("Error generating response export", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("surveyKey", surveyKey), slog.String("error", err.Error()))
+		return
+	}
+
+	err = exporter.Finish()
+	if err != nil {
+		slog.Error("failed to finish export", slog.String("error", err.Error()))
+		return
+	}
+	slog.Info("Generated response export", slog.String("path", responseFilePath))
+}
+
+func cleanUpForSource(sourceDir string) error {
+	cutoffDate := time.Now().Add(
+		time.Duration(-(conf.ResponseExports.RetentionDays + 1)) * time.Hour * 24,
+	)
+
+	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		// Parse date from filename (assuming format YYYY-MM-DD##responses##..##..)
+		basename := filepath.Base(path)
+		parts := strings.Split(basename, "##")
+		if len(parts) < 1 {
+			return nil
+		}
+		datePart := parts[0]
+		if len(datePart) < 10 {
+			return nil
+		}
+
+		fileDate, err := time.Parse("2006-01-02", datePart)
+		if err != nil {
+			return nil
+		}
+
+		if fileDate.Before(cutoffDate) {
+			if err := os.Remove(path); err != nil {
+				slog.Error("Failed to remove old file", slog.String("path", path), slog.String("error", err.Error()))
+			}
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
This pull request introduces a new feature for exporting confidential survey responses and refactors the existing response export functionality. The most important changes include adding new types for export tasks, implementing functions for exporting confidential responses, and refactoring the existing response export logic to improve maintainability.

### Breaking configuration changes

In order to be able to reuse the exporter job for multiple file formats, and other usability considerations, the config structure was changed. Please update the config.yaml file. 

Old format:
```
...
response_exports:
  export_path: "storage/daily-exports"
  retention_days: 365
  override_old: false
  export_format: "json"
  short_keys: true
  separator: "-"
  sources:
    - instance_id: "<instanceID>"
      study_key: "<studyKey>"
      survey_keys: ["<survey1>", "<survey2>"]
      extra_context_columns: []

```

New format:
```
...
export_path: "storage/daily-exports"
response_exports:
  retention_days: 365
  override_old: false
  export_tasks:
    - instance_id: "<instanceID>"
      study_key: "<studyKey>"
      survey_keys: ["<survey1>", "<survey2>"]
      extra_context_columns: []
      export_format: "json"
      short_keys: true
      separator: "-"
```

In summary:
- `export_path` moved to the root
- `sources` renamed to `export_tasks`
-  `export_format`, `short_keys`, `separator` can / should be specified per export task

With this you should be able to generate exports in different formats with one run of the exporter job.


### New export functionality for "confidential responses"

With this new feature the exporter job can be configured to prepare CSV or JSON exports for confidential data from all participants. 

To enable add the config for the export tasks in the config.yaml file.
```
conf_resp_exports:
  preserve_previous_files: false
  export_tasks:
    - name: "all"
      instance_id: "<instanceID>"
      study_key: "<studyKey>"
      study_global_secret: "<globalStudySecret>"
      resp_key_filter: []
      export_format: "json"
    - name: "all"
      instance_id: "<instanceID>"
      study_key: "<studyKey>"
      study_global_secret: "<globalStudySecret>"
      resp_key_filter: []
      export_format: "csv"
    - name: "phone"
       instance_id: "<instanceID>"
      study_key: "<studyKey>"
      study_global_secret: "<globalStudySecret>"
      resp_key_filter: [
        "T0_1.AO.05-rg.contact.phone"
        ]
      export_format: "csv"
```

- `preserve_previous_files`: if set to true, it won't clean up old confidential files. This can be useful, if you have multiple parallel instances of the sync job, to prevent on job to remove the files created by another. For a single job, it is likely better to use false, so only the most up to date file with the confidential responses is kept.
- each export task:
  - `name`: define a name for the task, that will also appear in the filename like: `2025-02-13##confidential-responses##phone##csv.csv`
  - `study_globel_secret`: should have the value as for other backend components. Required to be able to compute the correct participant IDs. 
  - `export_format`: JSON and CSV are supported
  - `resp_key_filter`: if the list has any items, only responses with this key will be included in the export file. 

The export feature for confidential responses requires the presence of the id mapping collection in the study DB. In case that's missing it won't be able to compute the participant IDs. In a future update, the user-management-job will support the creation of this ID mapping. 