### PR TITLE
Generate pid lookup

### DIFF
--- a/jobs/user-management/generate-id-lookup.go
+++ b/jobs/user-management/generate-id-lookup.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	studyService "github.com/case-framework/case-backend/pkg/study"
+	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
+	umTypes "github.com/case-framework/case-backend/pkg/user-management/types"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func generateProfileIDLookup() {
+	for _, instanceID := range conf.InstanceIDs {
+		slog.Debug("Start generating profile ID lookup", slog.String("instanceID", instanceID))
+
+		// get studies for this instance
+		studies, err := studyDBService.GetStudies(instanceID, studyTypes.STUDY_STATUS_ACTIVE, false)
+		if err != nil {
+			slog.Error("Failed to get studies", slog.String("instanceID", instanceID), slog.String("error", err.Error()))
+			continue
+		}
+
+		// call DB method participantUserDBService
+		filter := bson.M{}
+		err = participantUserDBService.FindAndExecuteOnUsers(
+			context.Background(),
+			instanceID,
+			filter,
+			nil,
+			false,
+			func(user umTypes.User, args ...interface{}) error {
+				for _, profile := range user.Profiles {
+					profileID := profile.ID.Hex()
+					for _, study := range studies {
+						studyKey := study.Key
+						_, confidentialID, err := studyService.ComputeParticipantIDs(study, profileID)
+						if err != nil {
+							slog.Error("Error computing participant IDs", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("error", err.Error()))
+							continue
+						}
+
+						_, err = studyDBService.GetProfileIDFromConfidentialID(instanceID, confidentialID, studyKey)
+						if err != nil {
+							// Create new lookup entry
+							if err = studyDBService.AddConfidentialIDMapEntry(instanceID, confidentialID, profileID, studyKey); err != nil {
+								slog.Error("Error saving participant ID profile lookup", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("error", err.Error()))
+								continue
+							}
+						}
+					}
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			slog.Error("Error generating profile ID lookup", slog.String("instanceID", instanceID), slog.String("error", err.Error()))
+			continue
+		}
+	}
+}

--- a/jobs/user-management/init.go
+++ b/jobs/user-management/init.go
@@ -66,6 +66,13 @@ type config struct {
 
 		ExternalServices []studyengine.ExternalService `json:"external_services" yaml:"external_services"`
 	} `json:"study_configs" yaml:"study_configs"`
+
+	RunTasks struct {
+		CleanUpUnverifiedUsers        bool `json:"clean_up_unverified_users" yaml:"clean_up_unverified_users"`
+		SendReminderToConfirmAccounts bool `json:"send_reminder_to_confirm_accounts" yaml:"send_reminder_to_confirm_accounts"`
+		HandleInactiveUsers           bool `json:"handle_inactive_users" yaml:"handle_inactive_users"`
+		GenerateProfileIDLookup       bool `json:"generate_profile_id_lookup" yaml:"generate_profile_id_lookup"`
+	} `json:"run_tasks" yaml:"run_tasks"`
 }
 
 var conf config

--- a/jobs/user-management/main.go
+++ b/jobs/user-management/main.go
@@ -30,6 +30,10 @@ func main() {
 		cleanUpUsersMarkedForDeletion()
 	}
 
+	if conf.RunTasks.GenerateProfileIDLookup {
+		generateProfileIDLookup()
+	}
+
 	slog.Info("User management jobs completed", slog.String("duration", time.Since(start).String()))
 }
 

--- a/jobs/user-management/main.go
+++ b/jobs/user-management/main.go
@@ -19,10 +19,16 @@ func main() {
 	slog.Info("Starting user management job")
 	start := time.Now()
 
-	cleanUpUnverifiedUsers()
-	sendReminderToConfirmAccounts()
-	notifyInactiveUsersAndMarkForDeletion()
-	cleanUpUsersMarkedForDeletion()
+	if conf.RunTasks.CleanUpUnverifiedUsers {
+		cleanUpUnverifiedUsers()
+	}
+	if conf.RunTasks.SendReminderToConfirmAccounts {
+		sendReminderToConfirmAccounts()
+	}
+	if conf.RunTasks.HandleInactiveUsers {
+		notifyInactiveUsersAndMarkForDeletion()
+		cleanUpUsersMarkedForDeletion()
+	}
 
 	slog.Info("User management jobs completed", slog.String("duration", time.Since(start).String()))
 }

--- a/pkg/db/study/db.go
+++ b/pkg/db/study/db.go
@@ -165,7 +165,9 @@ func (dbService *StudyDBService) ensureIndexes() error {
 				Keys: bson.D{
 					{Key: "confidentialID", Value: 1},
 					{Key: "studyKey", Value: 1},
-				}},
+				},
+				Options: options.Index().SetUnique(true),
+			},
 		)
 		if err != nil {
 			slog.Error("Error creating index for confidentialIDMap", slog.String("instanceID", instanceID), slog.String("error", err.Error()))

--- a/pkg/study/study-service.go
+++ b/pkg/study/study-service.go
@@ -79,7 +79,6 @@ func OnEnterStudy(instanceID string, studyKey string, profileID string) (result 
 		// save particicpant id profile lookup
 		if err = studyDBService.AddConfidentialIDMapEntry(instanceID, confidentialID, profileID, studyKey); err != nil {
 			slog.Error("Error saving participant ID profile lookup", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("error", err.Error()))
-			return
 		}
 	}
 
@@ -256,7 +255,6 @@ func OnMergeTempParticipant(instanceID string, studyKey string, profileID string
 		err = studyDBService.AddConfidentialIDMapEntry(instanceID, confidentialID, profileID, studyKey)
 		if err != nil {
 			slog.Error("Error saving participant ID lookup", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("participantID", participantID), slog.String("error", err.Error()))
-			return
 		}
 	}
 


### PR DESCRIPTION
This pull request introduces a new feature for generating a profile ID lookup and includes several other related changes. The most important changes include the addition of the `generateProfileIDLookup` function, updates to the configuration structure to include new tasks, modifications to the main execution flow to support the new tasks, and enhancements to database indexing and error handling.

### Breaking config change

New section needed to run the different tasks included in the job:
```
run_tasks:
  clean_up_unverified_users: true
  send_reminder_to_confirm_accounts: true
  handle_inactive_users: true
  generate_profile_id_lookup: false
```

The job currently supports 4 tasks:
- previously the first 3 task were running by default when the job started. Logic for these did not change, only that now they need to be explicitly included by setting their value to "true". This allows a more granular control what runs when if needed. 
- `generate_profile_id_lookup`: control if the new 

### New functionality generateProfileIDLookup for user-management job

When configured to run, this will create the `confidential-id-map` collection for all the active studies for all the configured instanceIDs. This can be helpful to retrospectively add this collection. Though it's safe to run it multiple times (it will create entries only once), but better to include it only when necessary (E.g. applying the migrating the backend).
The confidential-id-map:
- is needed to auto-prepare confidential data exports
- makes lookup of participant messages significantly more efficient


### Database Enhancements

* [`pkg/db/study/db.go`](diffhunk://#diff-e482b0132c132e11e3a8b78e1dbe2bc47c726aa830841ea3bd90b427c2fe5efcL168-R170): Updated the `ensureIndexes` function to set the `confidentialID` and `studyKey` index as unique, ensuring data integrity for the profile ID lookup.

### Error Handling Improvements

* [`pkg/study/study-service.go`](diffhunk://#diff-ff728f0f21cbce64cb2373dfd1697f8ed2a5d8cec581484c47c02b76b16e2de4L82): Removed `return` statements after logging errors in `OnEnterStudy` and `OnMergeTempParticipant` functions to streamline error handling - to prevent potential issues due to duplicated key. [[1]](diffhunk://#diff-ff728f0f21cbce64cb2373dfd1697f8ed2a5d8cec581484c47c02b76b16e2de4L82) [[2]](diffhunk://#diff-ff728f0f21cbce64cb2373dfd1697f8ed2a5d8cec581484c47c02b76b16e2de4L259)