### PR TITLE
Drop db indexes before creating

### DIFF
--- a/pkg/db/global-infos/temptoken.go
+++ b/pkg/db/global-infos/temptoken.go
@@ -2,6 +2,7 @@ package globalinfos
 
 import (
 	"errors"
+	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -15,6 +16,10 @@ import (
 func (dbService *GlobalInfosDBService) CreateIndexForTemptokens() error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
+
+	if _, err := dbService.collectionTemptokens().Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for temptokens", slog.String("error", err.Error()))
+	}
 
 	_, err := dbService.collectionTemptokens().Indexes().CreateMany(
 		ctx, []mongo.IndexModel{

--- a/pkg/db/management-user/management-users.go
+++ b/pkg/db/management-user/management-users.go
@@ -1,12 +1,32 @@
 package managementuser
 
 import (
+	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
+
+func (dbService *ManagementUserDBService) createIndexForManagementUsers(instanceID string) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	if _, err := dbService.collectionManagementUsers(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for management users: ", slog.String("error", err.Error()))
+	}
+
+	_, err := dbService.collectionManagementUsers(instanceID).Indexes().CreateOne(
+		ctx,
+		mongo.IndexModel{
+			Keys:    bson.D{{Key: "sub", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+	)
+	return err
+}
 
 func (dbService *ManagementUserDBService) CreateUser(
 	instanceID string,

--- a/pkg/db/management-user/permissions.go
+++ b/pkg/db/management-user/permissions.go
@@ -1,9 +1,35 @@
 package managementuser
 
 import (
+	"log/slog"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
+
+func (dbService *ManagementUserDBService) createIndexForPermissions(instanceID string) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	if _, err := dbService.collectionPermissions(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for permissions: ", slog.String("error", err.Error()))
+	}
+
+	_, err := dbService.collectionPermissions(instanceID).Indexes().CreateOne(
+		ctx,
+		mongo.IndexModel{
+			Keys: bson.D{
+				{Key: "subjectID", Value: 1},
+				{Key: "subjectType", Value: 1},
+				{Key: "resourceType", Value: 1},
+				{Key: "resourceID", Value: 1},
+				{Key: "action", Value: 1},
+			},
+		},
+	)
+	return err
+}
 
 // Create permission
 func (dbService *ManagementUserDBService) CreatePermission(

--- a/pkg/db/management-user/service-users.go
+++ b/pkg/db/management-user/service-users.go
@@ -21,6 +21,11 @@ func (dbService *ManagementUserDBService) collectionServiceUserAPIKeys(instanceI
 func (dbService *ManagementUserDBService) createIndexForServiceUserAPIKeys(instanceID string) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
+
+	if _, err := dbService.collectionServiceUserAPIKeys(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for service user API keys: ", slog.String("error", err.Error()))
+	}
+
 	_, err := dbService.collectionServiceUserAPIKeys(instanceID).Indexes().CreateMany(
 		ctx,
 		[]mongo.IndexModel{

--- a/pkg/db/messaging/db.go
+++ b/pkg/db/messaging/db.go
@@ -107,6 +107,10 @@ func (dbService *MessagingDBService) ensureIndexes() error {
 		defer cancel()
 
 		// Email Templates
+		if _, err := dbService.collectionEmailTemplates(instanceID).Indexes().DropAll(ctx); err != nil {
+			slog.Error("Error dropping indexes for email templates: ", slog.String("error", err.Error()))
+		}
+
 		_, err := dbService.collectionEmailTemplates(instanceID).Indexes().CreateOne(
 			ctx,
 			// index unique on messageType and studyKey combo:

--- a/pkg/db/messaging/sent-sms.go
+++ b/pkg/db/messaging/sent-sms.go
@@ -1,6 +1,7 @@
 package messaging
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/case-framework/case-backend/pkg/messaging/types"
@@ -12,6 +13,10 @@ import (
 func (dbService *MessagingDBService) CreateSentSMSIndex(instanceID string) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
+
+	if _, err := dbService.collectionSentSMS(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for sent SMS: ", slog.String("error", err.Error()))
+	}
 
 	_, err := dbService.collectionSentSMS(instanceID).Indexes().CreateMany(
 		ctx, []mongo.IndexModel{

--- a/pkg/db/participant-user/failedOtpAttempts.go
+++ b/pkg/db/participant-user/failedOtpAttempts.go
@@ -1,6 +1,7 @@
 package participantuser
 
 import (
+	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -20,6 +21,11 @@ type FailedOtpAttempt struct {
 func (dbService *ParticipantUserDBService) CreateIndexForFailedOtpAttempts(instanceID string) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
+
+	if _, err := dbService.collectionFailedOtpAttempts(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for FailedOtpAttempts", slog.String("error", err.Error()))
+	}
+
 	_, err := dbService.collectionFailedOtpAttempts(instanceID).Indexes().CreateMany(
 		ctx, []mongo.IndexModel{
 			{

--- a/pkg/db/participant-user/otps.go
+++ b/pkg/db/participant-user/otps.go
@@ -2,6 +2,7 @@ package participantuser
 
 import (
 	"errors"
+	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -18,6 +19,10 @@ const (
 func (dbService *ParticipantUserDBService) CreateIndexForOTPs(instanceID string) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
+
+	if _, err := dbService.collectionOTPs(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for OTPs", slog.String("error", err.Error()))
+	}
 
 	_, err := dbService.collectionOTPs(instanceID).Indexes().CreateMany(
 		ctx, []mongo.IndexModel{

--- a/pkg/db/participant-user/renew-tokens.go
+++ b/pkg/db/participant-user/renew-tokens.go
@@ -2,6 +2,7 @@ package participantuser
 
 import (
 	"errors"
+	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -19,6 +20,10 @@ const (
 func (dbService *ParticipantUserDBService) CreateIndexForRenewTokens(instanceID string) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
+
+	if _, err := dbService.collectionRenewTokens(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for renew tokens", slog.String("error", err.Error()))
+	}
 
 	_, err := dbService.collectionRenewTokens(instanceID).Indexes().CreateMany(
 		ctx, []mongo.IndexModel{

--- a/pkg/db/participant-user/users.go
+++ b/pkg/db/participant-user/users.go
@@ -18,6 +18,10 @@ func (dbService *ParticipantUserDBService) CreateIndexForParticipantUsers(instan
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
+	if _, err := dbService.collectionParticipantUsers(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for participant users", slog.String("error", err.Error()))
+	}
+
 	_, err := dbService.collectionParticipantUsers(instanceID).Indexes().CreateMany(
 		ctx, []mongo.IndexModel{
 			{

--- a/pkg/db/study/db.go
+++ b/pkg/db/study/db.go
@@ -141,6 +141,10 @@ func (dbService *StudyDBService) ensureIndexes() error {
 		defer cancel()
 
 		// task queue: auto delete on creation date
+		if _, err := dbService.collectionTaskQueue(instanceID).Indexes().DropAll(ctx); err != nil {
+			slog.Error("Error dropping indexes for task queue", slog.String("error", err.Error()))
+		}
+
 		_, err := dbService.collectionTaskQueue(instanceID).Indexes().CreateOne(
 			ctx,
 			mongo.IndexModel{
@@ -159,6 +163,10 @@ func (dbService *StudyDBService) ensureIndexes() error {
 		}
 
 		// index on confidentialIDMap
+		if _, err := dbService.collectionConfidentialIDMap(instanceID).Indexes().DropAll(ctx); err != nil {
+			slog.Error("Error dropping indexes for confidentialIDMap", slog.String("error", err.Error()))
+		}
+
 		_, err = dbService.collectionConfidentialIDMap(instanceID).Indexes().CreateOne(
 			ctx,
 			mongo.IndexModel{

--- a/pkg/db/study/participants.go
+++ b/pkg/db/study/participants.go
@@ -15,6 +15,10 @@ func (dbService *StudyDBService) CreateIndexForParticipantsCollection(instanceID
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
+	if _, err := dbService.collectionParticipants(instanceID, studyKey).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for participants", slog.String("error", err.Error()))
+	}
+
 	collection := dbService.collectionParticipants(instanceID, studyKey)
 	indexes := []mongo.IndexModel{
 		{

--- a/pkg/db/study/reports.go
+++ b/pkg/db/study/reports.go
@@ -17,6 +17,10 @@ func (dbService *StudyDBService) CreateIndexForReportsCollection(instanceID stri
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
+	if _, err := dbService.collectionReports(instanceID, studyKey).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for reports", slog.String("error", err.Error()))
+	}
+
 	collection := dbService.collectionReports(instanceID, studyKey)
 	indexes := []mongo.IndexModel{
 		{

--- a/pkg/db/study/responses.go
+++ b/pkg/db/study/responses.go
@@ -18,6 +18,10 @@ func (dbService *StudyDBService) CreateIndexForResponsesCollection(instanceID st
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
+	if _, err := dbService.collectionResponses(instanceID, studyKey).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for responses", slog.String("error", err.Error()))
+	}
+
 	collection := dbService.collectionResponses(instanceID, studyKey)
 	indexes := []mongo.IndexModel{
 		{

--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -1,6 +1,7 @@
 package study
 
 import (
+	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -13,6 +14,10 @@ import (
 func (dbService *StudyDBService) CreateIndexForStudyCodeListsCollection(instanceID string) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
+
+	if _, err := dbService.collectionStudyCodeLists(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for studyCodeLists", slog.String("error", err.Error()))
+	}
 
 	collection := dbService.collectionStudyCodeLists(instanceID)
 	indexes := []mongo.IndexModel{

--- a/pkg/db/study/studyInfos.go
+++ b/pkg/db/study/studyInfos.go
@@ -15,6 +15,10 @@ func (dbService *StudyDBService) createIndexForStudyInfosCollection(instanceID s
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
+	if _, err := dbService.collectionStudyInfos(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for studyInfos", slog.String("error", err.Error()))
+	}
+
 	_, err := dbService.collectionStudyInfos(instanceID).Indexes().CreateOne(
 		ctx,
 		mongo.IndexModel{

--- a/pkg/db/study/studyRules.go
+++ b/pkg/db/study/studyRules.go
@@ -1,6 +1,8 @@
 package study
 
 import (
+	"log/slog"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -12,6 +14,10 @@ import (
 func (dbService *StudyDBService) CreateIndexForStudyRulesCollection(instanceID string) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
+
+	if _, err := dbService.collectionStudyRules(instanceID).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for studyRules", slog.String("error", err.Error()))
+	}
 
 	collection := dbService.collectionStudyRules(instanceID)
 	indexes := []mongo.IndexModel{

--- a/pkg/db/study/surveys.go
+++ b/pkg/db/study/surveys.go
@@ -2,6 +2,7 @@ package study
 
 import (
 	"errors"
+	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -15,6 +16,10 @@ import (
 func (dbService *StudyDBService) CreateIndexForSurveyCollection(instanceID string, studyKey string) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
+
+	if _, err := dbService.collectionSurveys(instanceID, studyKey).Indexes().DropAll(ctx); err != nil {
+		slog.Error("Error dropping indexes for surveys", slog.String("error", err.Error()))
+	}
 
 	collection := dbService.collectionSurveys(instanceID, studyKey)
 	indexes := []mongo.IndexModel{


### PR DESCRIPTION
In many cases, there are error messages about existing index with different names or options. To ensure the right indexes are present, when using the DB init with index creation option, it will first drop all indexes on the collection before adding the specified indexes. 
If the setup is using manually added indexes, don't use the auto index creation because it will now remove the manually added ones.

### Enhancements to Indexing and Logging:

* **Global Infos:**
  * Added logging for errors when dropping indexes in `CreateIndexForTemptokens` function. (`pkg/db/global-infos/temptoken.go`)

* **Management User:**
  * Refactored index creation into separate functions (`createIndexForManagementUsers`, `createIndexForPermissions`, `createIndexForSessions`, etc.) and added error logging for index dropping operations. (`pkg/db/management-user/management-users.go`, `pkg/db/management-user/permissions.go`, `pkg/db/management-user/sessions.go`) [[1]](diffhunk://#diff-00f4f03feeba6290fb69f48934ba50cacbcba92dc0020987eaa0c75f1c070653R4-R30) [[2]](diffhunk://#diff-5a66a6184bdc65a76ad65c96d41724eb2fe7cb1e392919bce54bcbb93c08e31fR4-R33) [[3]](diffhunk://#diff-65b907e59d15d4f4df4bad0d6d55e92e2bf9ff59817a0b26302e887347326fe5R4-R35)
  * Removed redundant context creation and cancellation in `ensureIndexes` function and replaced it with calls to the new index creation functions. (`pkg/db/management-user/db.go`)

* **Participant User:**
  * Added error logging for index dropping operations in various index creation functions (`CreateIndexForFailedOtpAttempts`, `CreateIndexForOTPs`, `CreateIndexForRenewTokens`, etc.). (`pkg/db/participant-user/failedOtpAttempts.go`, `pkg/db/participant-user/otps.go`, `pkg/db/participant-user/renew-tokens.go`, `pkg/db/participant-user/users.go`) [[1]](diffhunk://#diff-b8e18a782d122b8a1de6ba568d091f79fbd99a5064aa4e134ade24c156026f39R24-R28) [[2]](diffhunk://#diff-737ffaa7b5e56f27856cc1c4eff6d5915b6ded96117cdea10122dd8bc02cc801R23-R26) [[3]](diffhunk://#diff-717a66bc8bf26a9e823b3a18ebff5cda628db16929ece4e4ff4f812096159e9dR24-R27) [[4]](diffhunk://#diff-a27ce9ce5be41a3125aba63f8728650e3d221509448fb478b6362701853cb243R21-R24)

* **Study:**
  * Added error logging for index dropping operations in various index creation functions (`CreateIndexForParticipantsCollection`, `CreateIndexForReportsCollection`, `CreateIndexForResponsesCollection`, etc.). (`pkg/db/study/participants.go`, `pkg/db/study/reports.go`, `pkg/db/study/responses.go`, `pkg/db/study/study-code-lists.go`, `pkg/db/study/studyInfos.go`, `pkg/db/study/studyRules.go`, `pkg/db/study/surveys.go`) [[1]](diffhunk://#diff-f51ad8036e23e7fbb281ae5f48ffd33948ca9704407aab31c3c7c76e6b3569a0R18-R21) [[2]](diffhunk://#diff-1e91b366c4f3bbc012089ca4b078efeb92a270ccc0a475815f03d3365ac10560R20-R23) [[3]](diffhunk://#diff-c747cd54ab28a8fe3d528901711953bc8ea55dd5005dd369a9038fbebe46f3e7R21-R24) [[4]](diffhunk://#diff-325e9b9e95644bc13e8cf39705392d89b707112061a7bb9425242f83d4ea373aR18-R21) [[5]](diffhunk://#diff-32b584f776d090c98f943bd8f1f0e3c1c6f72b9a618bb804d61f284078f11f55R18-R21) [[6]](diffhunk://#diff-bf5c0025245a5bc55dfbf00d92d16c3eed9760e2c1dc2056382001dfa6aaa346R18-R21) [[7]](diffhunk://#diff-78279bdc363219e8ab0a9d17d38d584bfb653443b2fe7a4fa2b6f52e4de2d1ebR20-R23)

* **Messaging:**
  * Added error logging for index dropping operations in `CreateSentSMSIndex` function and other related functions. (`pkg/db/messaging/sent-sms.go`, `pkg/db/messaging/db.go`) [[1]](diffhunk://#diff-7c00c3ffc6d68614a587c370c8c1fca7f5435cb287889e4f5cc2fd0610e3ef04R17-R20) [[2]](diffhunk://#diff-42fec81cddda9c58c93cd7cb20abf7082b46578b97c5e1786bca9d247dd3fb07R110-R113)

These changes improve error visibility and maintainability by ensuring that any issues encountered during index dropping are logged, and by organizing index creation logic into dedicated functions.