### PR TITLE
Prefill improvements

### DIFF
--- a/pkg/study/studyengine/actions.go
+++ b/pkg/study/studyengine/actions.go
@@ -185,7 +185,7 @@ func updateStudyStatusAction(action studyTypes.Expression, oldState ActionData, 
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -222,11 +222,11 @@ func updateFlagAction(action studyTypes.Expression, oldState ActionData, event S
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
-	v, err := EvalContext.expressionArgResolver(action.Data[1])
+	v, err := EvalContext.ExpressionArgResolver(action.Data[1])
 	if err != nil {
 		return newState, err
 	}
@@ -268,7 +268,7 @@ func removeFlagAction(action studyTypes.Expression, oldState ActionData, event S
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -298,7 +298,7 @@ func setLinkingCodeAction(action studyTypes.Expression, oldState ActionData, eve
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -308,7 +308,7 @@ func setLinkingCodeAction(action studyTypes.Expression, oldState ActionData, eve
 		return newState, errors.New("could not parse key")
 	}
 
-	v, err := EvalContext.expressionArgResolver(action.Data[1])
+	v, err := EvalContext.ExpressionArgResolver(action.Data[1])
 	if err != nil {
 		return newState, err
 	}
@@ -340,7 +340,7 @@ func deleteLinkingCodeAction(action studyTypes.Expression, oldState ActionData, 
 			Event:            event,
 			ParticipantState: newState.PState,
 		}
-		k, err := EvalContext.expressionArgResolver(action.Data[0])
+		k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 		if err != nil {
 			return newState, err
 		}
@@ -372,19 +372,19 @@ func addNewSurveyAction(action studyTypes.Expression, oldState ActionData, event
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
-	start, err := EvalContext.expressionArgResolver(action.Data[1])
+	start, err := EvalContext.ExpressionArgResolver(action.Data[1])
 	if err != nil {
 		return newState, err
 	}
-	end, err := EvalContext.expressionArgResolver(action.Data[2])
+	end, err := EvalContext.ExpressionArgResolver(action.Data[2])
 	if err != nil {
 		return newState, err
 	}
-	c, err := EvalContext.expressionArgResolver(action.Data[3])
+	c, err := EvalContext.ExpressionArgResolver(action.Data[3])
 	if err != nil {
 		return newState, err
 	}
@@ -432,11 +432,11 @@ func removeSurveyByKey(action studyTypes.Expression, oldState ActionData, event 
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
-	pos, err := EvalContext.expressionArgResolver(action.Data[1])
+	pos, err := EvalContext.ExpressionArgResolver(action.Data[1])
 	if err != nil {
 		return newState, err
 	}
@@ -491,7 +491,7 @@ func removeSurveysByKey(action studyTypes.Expression, oldState ActionData, event
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -522,11 +522,11 @@ func addMessage(action studyTypes.Expression, oldState ActionData, event StudyEv
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	arg1, err := EvalContext.expressionArgResolver(action.Data[0])
+	arg1, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
-	arg2, err := EvalContext.expressionArgResolver(action.Data[1])
+	arg2, err := EvalContext.ExpressionArgResolver(action.Data[1])
 	if err != nil {
 		return newState, err
 	}
@@ -568,7 +568,7 @@ func removeMessagesByType(action studyTypes.Expression, oldState ActionData, eve
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -599,7 +599,7 @@ func notifyResearcher(action studyTypes.Expression, oldState ActionData, event S
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -612,11 +612,11 @@ func notifyResearcher(action studyTypes.Expression, oldState ActionData, event S
 	payload := map[string]string{}
 
 	for i := 1; i < len(action.Data)-1; i = i + 2 {
-		k, err := EvalContext.expressionArgResolver(action.Data[i])
+		k, err := EvalContext.ExpressionArgResolver(action.Data[i])
 		if err != nil {
 			return newState, err
 		}
-		v, err := EvalContext.expressionArgResolver(action.Data[i+1])
+		v, err := EvalContext.ExpressionArgResolver(action.Data[i+1])
 		if err != nil {
 			return newState, err
 		}
@@ -656,7 +656,7 @@ func initReport(action studyTypes.Expression, oldState ActionData, event StudyEv
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -684,7 +684,7 @@ func updateReportData(action studyTypes.Expression, oldState ActionData, event S
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		slog.Error("unexpected error during action", slog.String("action", action.Name), slog.String("error", err.Error()))
 		return newState, err
@@ -706,7 +706,7 @@ func updateReportData(action studyTypes.Expression, oldState ActionData, event S
 	}
 
 	// Get attribute Key
-	a, err := EvalContext.expressionArgResolver(action.Data[1])
+	a, err := EvalContext.ExpressionArgResolver(action.Data[1])
 	if err != nil {
 		slog.Debug("error during action", slog.String("action", action.Name), slog.String("error", err.Error()))
 		return newState, err
@@ -717,7 +717,7 @@ func updateReportData(action studyTypes.Expression, oldState ActionData, event S
 	}
 
 	// Get value
-	v, err := EvalContext.expressionArgResolver(action.Data[2])
+	v, err := EvalContext.ExpressionArgResolver(action.Data[2])
 	if err != nil {
 		slog.Debug("error during action", slog.String("action", action.Name), slog.String("error", err.Error()))
 		return newState, err
@@ -726,7 +726,7 @@ func updateReportData(action studyTypes.Expression, oldState ActionData, event S
 	dType := ""
 	if len(action.Data) > 3 {
 		// Set dtype
-		d, err := EvalContext.expressionArgResolver(action.Data[3])
+		d, err := EvalContext.ExpressionArgResolver(action.Data[3])
 		if err != nil {
 			return newState, err
 		}
@@ -785,7 +785,7 @@ func removeReportData(action studyTypes.Expression, oldState ActionData, event S
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -803,7 +803,7 @@ func removeReportData(action studyTypes.Expression, oldState ActionData, event S
 	}
 
 	// Get attribute Key
-	a, err := EvalContext.expressionArgResolver(action.Data[1])
+	a, err := EvalContext.ExpressionArgResolver(action.Data[1])
 	if err != nil {
 		return newState, err
 	}
@@ -838,7 +838,7 @@ func cancelReport(action studyTypes.Expression, oldState ActionData, event Study
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -865,7 +865,7 @@ func removeConfidentialResponseByKey(action studyTypes.Expression, oldState Acti
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -905,7 +905,7 @@ func externalEventHandler(action studyTypes.Expression, oldState ActionData, eve
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	k, err := EvalContext.expressionArgResolver(action.Data[0])
+	k, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -923,7 +923,7 @@ func externalEventHandler(action studyTypes.Expression, oldState ActionData, eve
 
 	pathname := ""
 	if len(action.Data) > 1 {
-		arg1, err := EvalContext.expressionArgResolver(action.Data[1])
+		arg1, err := EvalContext.ExpressionArgResolver(action.Data[1])
 		if err != nil {
 			return newState, err
 		}
@@ -994,7 +994,7 @@ func removeStudyCode(action studyTypes.Expression, oldState ActionData, event St
 		Event:            event,
 		ParticipantState: newState.PState,
 	}
-	arg1, err := EvalContext.expressionArgResolver(action.Data[0])
+	arg1, err := EvalContext.ExpressionArgResolver(action.Data[0])
 	if err != nil {
 		return newState, err
 	}
@@ -1004,7 +1004,7 @@ func removeStudyCode(action studyTypes.Expression, oldState ActionData, event St
 		return newState, errors.New("could not parse arguments")
 	}
 
-	arg2, err := EvalContext.expressionArgResolver(action.Data[1])
+	arg2, err := EvalContext.ExpressionArgResolver(action.Data[1])
 	if err != nil {
 		return newState, err
 	}

--- a/pkg/study/studyengine/expressions.go
+++ b/pkg/study/studyengine/expressions.go
@@ -159,7 +159,7 @@ func ExpressionEval(expression studyTypes.Expression, evalCtx EvalContext) (val 
 	return
 }
 
-func (ctx EvalContext) expressionArgResolver(arg studyTypes.ExpressionArg) (interface{}, error) {
+func (ctx EvalContext) ExpressionArgResolver(arg studyTypes.ExpressionArg) (interface{}, error) {
 	switch arg.DType {
 	case "num":
 		return arg.Num, nil
@@ -181,7 +181,7 @@ func (ctx EvalContext) checkEventType(exp studyTypes.Expression) (val bool, err 
 		return val, errors.New("unexpected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -199,7 +199,7 @@ func (ctx EvalContext) checkEventKey(exp studyTypes.Expression) (val bool, err e
 		return val, errors.New("unexpected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -217,7 +217,7 @@ func (ctx EvalContext) checkSurveyResponseKey(exp studyTypes.Expression) (val bo
 		return val, errors.New("unexpected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -255,7 +255,7 @@ func (ctx EvalContext) isStudyCodePresent(exp studyTypes.Expression) (val bool, 
 		return val, errors.New("studyCodeExists: invalid number of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -264,7 +264,7 @@ func (ctx EvalContext) isStudyCodePresent(exp studyTypes.Expression) (val bool, 
 		return val, errors.New("could not cast arguments")
 	}
 
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -308,7 +308,7 @@ func (ctx EvalContext) checkConditionForOldResponses(exp studyTypes.Expression) 
 	since := int64(0)
 	until := int64(0)
 	if argNum > 1 {
-		arg1, err := ctx.expressionArgResolver(exp.Data[1])
+		arg1, err := ctx.ExpressionArgResolver(exp.Data[1])
 		if err != nil {
 			return val, err
 		}
@@ -329,7 +329,7 @@ func (ctx EvalContext) checkConditionForOldResponses(exp studyTypes.Expression) 
 		}
 	}
 	if argNum > 3 {
-		arg4, err := ctx.expressionArgResolver(exp.Data[3])
+		arg4, err := ctx.ExpressionArgResolver(exp.Data[3])
 		if err != nil {
 			return val, err
 		}
@@ -340,7 +340,7 @@ func (ctx EvalContext) checkConditionForOldResponses(exp studyTypes.Expression) 
 
 	}
 	if argNum > 4 {
-		arg5, err := ctx.expressionArgResolver(exp.Data[4])
+		arg5, err := ctx.ExpressionArgResolver(exp.Data[4])
 		if err != nil {
 			return val, err
 		}
@@ -532,7 +532,7 @@ func (ctx EvalContext) hasSurveyKeyAssigned(exp studyTypes.Expression, withIncom
 	if len(exp.Data) != 1 || !exp.Data[0].IsString() {
 		return val, errors.New("unexpected number or wrong type of argument")
 	}
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -584,7 +584,7 @@ func (ctx EvalContext) getSurveyKeyAssignedUntil(exp studyTypes.Expression, with
 	if len(exp.Data) != 1 || !exp.Data[0].IsString() {
 		return val, errors.New("unexpected number or wrong type of argument")
 	}
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -616,7 +616,7 @@ func (ctx EvalContext) hasParticipantFlagKey(exp studyTypes.Expression, withInco
 		return val, errors.New("unexpected argument types")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -645,7 +645,7 @@ func (ctx EvalContext) getParticipantFlagValue(exp studyTypes.Expression, withIn
 		return val, errors.New("unexpected argument types")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -674,7 +674,7 @@ func (ctx EvalContext) hasParticipantFlag(exp studyTypes.Expression, withIncomin
 		return val, errors.New("unexpected argument types")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -683,7 +683,7 @@ func (ctx EvalContext) hasParticipantFlag(exp studyTypes.Expression, withIncomin
 		return val, errors.New("could not cast argument 1")
 	}
 
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -712,7 +712,7 @@ func (ctx EvalContext) hasLinkingCode(exp studyTypes.Expression, withIncomingPar
 		return val, errors.New("unexpected argument types")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -741,7 +741,7 @@ func (ctx EvalContext) getLinkingCode(exp studyTypes.Expression, withIncomingPar
 		return val, errors.New("unexpected argument types")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -774,7 +774,7 @@ func (ctx EvalContext) getLastSubmissionDate(exp studyTypes.Expression, withInco
 		return float64(maxTs), nil
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -797,7 +797,7 @@ func (ctx EvalContext) lastSubmissionDateOlderThan(exp studyTypes.Expression, wi
 		return val, errors.New("unexpected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -833,7 +833,7 @@ func (ctx EvalContext) responseHasKeysAny(exp studyTypes.Expression) (val bool, 
 		return val, errors.New("unexpected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -841,7 +841,7 @@ func (ctx EvalContext) responseHasKeysAny(exp studyTypes.Expression) (val bool, 
 	if !ok {
 		return val, errors.New("could not cast arguments")
 	}
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -852,7 +852,7 @@ func (ctx EvalContext) responseHasKeysAny(exp studyTypes.Expression) (val bool, 
 
 	targetKeys := []string{}
 	for _, d := range exp.Data[2:] {
-		arg, err := ctx.expressionArgResolver(d)
+		arg, err := ctx.ExpressionArgResolver(d)
 		if err != nil {
 			return val, err
 		}
@@ -897,7 +897,7 @@ func (ctx EvalContext) responseHasOnlyKeysOtherThan(exp studyTypes.Expression) (
 		return val, errors.New("unexpected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -905,7 +905,7 @@ func (ctx EvalContext) responseHasOnlyKeysOtherThan(exp studyTypes.Expression) (
 	if !ok {
 		return val, errors.New("could not cast arguments")
 	}
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -916,7 +916,7 @@ func (ctx EvalContext) responseHasOnlyKeysOtherThan(exp studyTypes.Expression) (
 
 	targetKeys := []string{}
 	for _, d := range exp.Data[2:] {
-		arg, err := ctx.expressionArgResolver(d)
+		arg, err := ctx.ExpressionArgResolver(d)
 		if err != nil {
 			return val, err
 		}
@@ -965,7 +965,7 @@ func (ctx EvalContext) getResponseValueAsNum(exp studyTypes.Expression) (val flo
 		return val, errors.New("unexpected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -973,7 +973,7 @@ func (ctx EvalContext) getResponseValueAsNum(exp studyTypes.Expression) (val flo
 	if !ok {
 		return val, errors.New("could not cast arguments")
 	}
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -1004,7 +1004,7 @@ func (ctx EvalContext) getResponseValueAsStr(exp studyTypes.Expression) (val str
 		return val, errors.New("unexpected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -1012,7 +1012,7 @@ func (ctx EvalContext) getResponseValueAsStr(exp studyTypes.Expression) (val str
 	if !ok {
 		return val, errors.New("could not cast arguments")
 	}
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -1042,7 +1042,7 @@ func (ctx EvalContext) getSelectedKeys(exp studyTypes.Expression) (val string, e
 		return val, errors.New("unexpected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -1050,7 +1050,7 @@ func (ctx EvalContext) getSelectedKeys(exp studyTypes.Expression) (val string, e
 	if !ok {
 		return val, errors.New("could not cast arguments")
 	}
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -1184,11 +1184,11 @@ func (ctx EvalContext) eq(exp studyTypes.Expression) (val bool, err error) {
 		return val, errors.New("not expected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -1216,11 +1216,11 @@ func (ctx EvalContext) lt(exp studyTypes.Expression) (val bool, err error) {
 		return val, errors.New("not expected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -1248,11 +1248,11 @@ func (ctx EvalContext) lte(exp studyTypes.Expression) (val bool, err error) {
 		return val, errors.New("not expected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -1280,11 +1280,11 @@ func (ctx EvalContext) gt(exp studyTypes.Expression) (val bool, err error) {
 		return val, errors.New("not expected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -1312,11 +1312,11 @@ func (ctx EvalContext) gte(exp studyTypes.Expression) (val bool, err error) {
 		return val, errors.New("not expected numbers of arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -1347,7 +1347,7 @@ func (ctx EvalContext) hasMessageTypeAssigned(exp studyTypes.Expression, withInc
 	if len(exp.Data) != 1 {
 		return val, errors.New("should have at exactly one argument")
 	}
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -1367,7 +1367,7 @@ func (ctx EvalContext) getMessageNextTime(exp studyTypes.Expression, withIncomin
 	if len(exp.Data) != 1 {
 		return val, errors.New("should have at exactly one argument")
 	}
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -1392,7 +1392,7 @@ func (ctx EvalContext) and(exp studyTypes.Expression) (val bool, err error) {
 	}
 
 	for _, d := range exp.Data {
-		arg1, err := ctx.expressionArgResolver(d)
+		arg1, err := ctx.ExpressionArgResolver(d)
 		if err != nil {
 			return val, err
 		}
@@ -1416,7 +1416,7 @@ func (ctx EvalContext) or(exp studyTypes.Expression) (val bool, err error) {
 	}
 
 	for _, d := range exp.Data {
-		arg1, err := ctx.expressionArgResolver(d)
+		arg1, err := ctx.ExpressionArgResolver(d)
 		if err != nil {
 			slog.Debug("unexpected error during expression eval", slog.String("expression", exp.Name), slog.String("error", err.Error()))
 			continue
@@ -1440,7 +1440,7 @@ func (ctx EvalContext) not(exp studyTypes.Expression) (val bool, err error) {
 		return val, errors.New("should have one argument")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -1458,7 +1458,7 @@ func (ctx EvalContext) not(exp studyTypes.Expression) (val bool, err error) {
 
 func (ctx EvalContext) sum(exp studyTypes.Expression) (t float64, err error) {
 	for idx, dataExp := range exp.Data {
-		arg, err := ctx.expressionArgResolver(dataExp)
+		arg, err := ctx.ExpressionArgResolver(dataExp)
 		if err != nil {
 			slog.Error("unexpected error during expression eval", slog.Int("index", idx), slog.String("expression", exp.Name), slog.String("error", err.Error()))
 			continue
@@ -1483,7 +1483,7 @@ func (ctx EvalContext) neg(exp studyTypes.Expression) (val float64, err error) {
 		return val, errors.New("should have one argument")
 	}
 
-	arg, err := ctx.expressionArgResolver(exp.Data[0])
+	arg, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -1500,7 +1500,7 @@ func (ctx EvalContext) timestampWithOffset(exp studyTypes.Expression) (t float64
 		return t, errors.New("should have one or two arguments")
 	}
 
-	arg1, err1 := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err1 := ctx.ExpressionArgResolver(exp.Data[0])
 	if err1 != nil {
 		return t, err1
 	}
@@ -1511,7 +1511,7 @@ func (ctx EvalContext) timestampWithOffset(exp studyTypes.Expression) (t float64
 
 	referenceTime := Now().Unix()
 	if len(exp.Data) == 2 {
-		arg2, err2 := ctx.expressionArgResolver(exp.Data[1])
+		arg2, err2 := ctx.ExpressionArgResolver(exp.Data[1])
 		if err2 != nil {
 			return t, err2
 		}
@@ -1531,7 +1531,7 @@ func (ctx EvalContext) getTsForNextISOWeek(exp studyTypes.Expression) (t float64
 		return t, errors.New("should have one or two arguments")
 	}
 
-	arg1, err1 := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err1 := ctx.ExpressionArgResolver(exp.Data[0])
 	if err1 != nil {
 		return t, err1
 	}
@@ -1547,7 +1547,7 @@ func (ctx EvalContext) getTsForNextISOWeek(exp studyTypes.Expression) (t float64
 
 	referenceTime := Now()
 	if len(exp.Data) == 2 {
-		arg2, err2 := ctx.expressionArgResolver(exp.Data[1])
+		arg2, err2 := ctx.ExpressionArgResolver(exp.Data[1])
 		if err2 != nil {
 			return t, err2
 		}
@@ -1576,7 +1576,7 @@ func (ctx EvalContext) getISOWeekForTs(exp studyTypes.Expression) (t float64, er
 		return t, errors.New("should have one argument")
 	}
 
-	arg1, err1 := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err1 := ctx.ExpressionArgResolver(exp.Data[0])
 	if err1 != nil {
 		return t, err1
 	}
@@ -1595,7 +1595,7 @@ func (ctx EvalContext) parseValueAsNum(exp studyTypes.Expression) (val float64, 
 		return val, errors.New("should have one argument")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -1618,7 +1618,7 @@ func (ctx EvalContext) generateRandomNumber(exp studyTypes.Expression) (val floa
 		return val, errors.New("should have two arguments")
 	}
 
-	arg1, err := ctx.expressionArgResolver(exp.Data[0])
+	arg1, err := ctx.ExpressionArgResolver(exp.Data[0])
 	if err != nil {
 		return val, err
 	}
@@ -1627,7 +1627,7 @@ func (ctx EvalContext) generateRandomNumber(exp studyTypes.Expression) (val floa
 	}
 	min := int(arg1.(float64))
 
-	arg2, err := ctx.expressionArgResolver(exp.Data[1])
+	arg2, err := ctx.ExpressionArgResolver(exp.Data[1])
 	if err != nil {
 		return val, err
 	}
@@ -1660,7 +1660,7 @@ func (ctx EvalContext) externalEventEval(exp studyTypes.Expression) (val interfa
 	pathname := ""
 
 	if len(exp.Data) > 1 {
-		arg1, err := ctx.expressionArgResolver(exp.Data[1])
+		arg1, err := ctx.ExpressionArgResolver(exp.Data[1])
 		if err != nil {
 			return val, err
 		}
@@ -1711,7 +1711,7 @@ func (ctx EvalContext) externalEventEval(exp studyTypes.Expression) (val interfa
 }
 
 func (ctx EvalContext) mustGetStrValue(arg studyTypes.ExpressionArg) (string, error) {
-	arg1, err := ctx.expressionArgResolver(arg)
+	arg1, err := ctx.ExpressionArgResolver(arg)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This pull request is focusing on improving the handling of survey prefill rules. The most important changes include adding a new function to remove non-existing prefill slots, modifying the `resolvePrefillRules` function, and refactoring the method calls in the `studyengine` package.

### Improvements to survey prefill handling:
* Added a new function `removeNonExistingPrefillSlots` to clean up prefill slots that do not exist in the survey definition (`pkg/study/participant-data.go`).
* Modified the `resolvePrefillRules` function to handle the new prefill item type `PREFILL_ITEM_WITH_LAST_RESPONSE` and added a time filter resolution (`pkg/study/participant-data.go`).

### Refactoring for consistency:
* Changed all instances of `EvalContext.expressionArgResolver` to `EvalContext.ExpressionArgResolver` in the `studyengine` package for consistency (`pkg/study/studyengine/actions.go`). [[1]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L188-R188) [[2]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L225-R229) [[3]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L271-R271) [[4]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L301-R301) [[5]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L311-R311) [[6]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L343-R343) [[7]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L375-R387) [[8]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L435-R439) [[9]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L494-R494) [[10]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L525-R529) [[11]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L571-R571) [[12]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L602-R602) [[13]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L615-R619) [[14]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L659-R659) [[15]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L687-R687) [[16]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L709-R709) [[17]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L720-R720) [[18]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L729-R729) [[19]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L788-R788) [[20]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L806-R806) [[21]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L841-R841) [[22]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L868-R868) [[23]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L908-R908) [[24]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783L926-R926)

### Import adjustments:
* Added a new import for `studyengine` in `pkg/study/participant-data.go` to support the new functionality (`pkg/study/participant-data.go`).

### Code simplification:
* Removed unnecessary nil check for `rules` in `resolvePrefillRules` function (`pkg/study/participant-data.go`).