### PR TITLE
fix: trim whitespace from OTP code and enhance logging for verificati…

### DIFF
--- a/services/participant-api/apihandlers/authentication.go
+++ b/services/participant-api/apihandlers/authentication.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	mw "github.com/case-framework/case-backend/pkg/apihelpers/middlewares"
@@ -883,13 +884,14 @@ func (h *HttpEndpoints) verifyOTP(c *gin.Context) {
 	}
 
 	// user management method to verify OTP
+	code := strings.TrimSpace(req.Code)
 	otp, err := usermanagement.VerifyOTP(
 		token.InstanceID,
 		token.Subject,
-		req.Code,
+		code,
 	)
 	if err != nil {
-		slog.Warn("failed to verify OTP", slog.String("error", err.Error()))
+		slog.Warn("failed to verify OTP", slog.String("error", err.Error()), slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject))
 		if err := h.userDBConn.AddFailedOtpAttempt(token.InstanceID, token.Subject); err != nil {
 			slog.Error("failed to add failed otp attempt", slog.String("error", err.Error()))
 		}


### PR DESCRIPTION
This pull request includes changes to the `services/participant-api/apihandlers/authentication.go` file to improve the handling of OTP verification and logging.

Improvements to OTP verification:

* [`services/participant-api/apihandlers/authentication.go`](diffhunk://#diff-e6f1e5841f285814dda1d6986850a81af813286edd52d10aac2b095179dc9b6eR7): Added `strings` import to trim whitespace from the OTP code before verification.
* [`services/participant-api/apihandlers/authentication.go`](diffhunk://#diff-e6f1e5841f285814dda1d6986850a81af813286edd52d10aac2b095179dc9b6eR887-R894): Modified `verifyOTP` function to use `strings.TrimSpace` on the OTP code to ensure no leading or trailing spaces cause verification issues.

Enhancements to logging:

* [`services/participant-api/apihandlers/authentication.go`](diffhunk://#diff-e6f1e5841f285814dda1d6986850a81af813286edd52d10aac2b095179dc9b6eR887-R894): Enhanced logging in `verifyOTP` function to include `instanceID` and `userID` when OTP verification fails.