### PR TITLE
Study code list improvements

### DIFF
--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -139,7 +139,7 @@ func (dbService *StudyDBService) DeleteStudyCodeListEntry(instanceID string, stu
 	return err
 }
 
-func (dbService *StudyDBService) DrawStudyCode(instanceID string, studyKey string, listKey string) (*types.StudyCodeListEntry, error) {
+func (dbService *StudyDBService) DrawStudyCode(instanceID string, studyKey string, listKey string) (string, error) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
@@ -152,9 +152,9 @@ func (dbService *StudyDBService) DrawStudyCode(instanceID string, studyKey strin
 	err := dbService.collectionStudyCodeLists(instanceID).FindOneAndDelete(ctx, filter).Decode(&result)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
-			return nil, nil
+			return "", nil
 		}
-		return nil, err
+		return "", err
 	}
-	return &result, nil
+	return result.Code, nil
 }

--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -139,6 +139,14 @@ func (dbService *StudyDBService) DeleteStudyCodeListEntry(instanceID string, stu
 	return err
 }
 
+func (dbService *StudyDBService) DeleteStudyCodeListsForStudy(instanceID string, studyKey string) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	_, err := dbService.collectionStudyCodeLists(instanceID).DeleteMany(ctx, bson.M{"studyKey": studyKey})
+	return err
+}
+
 func (dbService *StudyDBService) DrawStudyCode(instanceID string, studyKey string, listKey string) (string, error) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()

--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -8,6 +8,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
+	"github.com/case-framework/case-backend/pkg/study/types"
 	studytypes "github.com/case-framework/case-backend/pkg/study/types"
 )
 
@@ -123,4 +124,24 @@ func (dbService *StudyDBService) DeleteStudyCodeListEntry(instanceID string, stu
 
 	_, err := dbService.collectionStudyCodeLists(instanceID).DeleteOne(ctx, filter)
 	return err
+}
+
+func (dbService *StudyDBService) DrawStudyCode(instanceID string, studyKey string, listKey string) (*types.StudyCodeListEntry, error) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	filter := bson.M{
+		"studyKey": studyKey,
+		"listKey":  listKey,
+	}
+
+	var result types.StudyCodeListEntry
+	err := dbService.collectionStudyCodeLists(instanceID).FindOneAndDelete(ctx, filter).Decode(&result)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &result, nil
 }

--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -112,6 +112,19 @@ func (dbService *StudyDBService) StudyCodeListEntryExists(instanceID string, stu
 	return count > 0, err
 }
 
+func (dbService *StudyDBService) DeleteStudyCodeListEntries(instanceID string, studyKey string, listKey string) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	filter := bson.M{
+		"studyKey": studyKey,
+		"listKey":  listKey,
+	}
+
+	_, err := dbService.collectionStudyCodeLists(instanceID).DeleteMany(ctx, filter)
+	return err
+}
+
 func (dbService *StudyDBService) DeleteStudyCodeListEntry(instanceID string, studyKey string, listKey string, code string) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()

--- a/pkg/db/study/studyInfos.go
+++ b/pkg/db/study/studyInfos.go
@@ -270,6 +270,11 @@ func (dbService *StudyDBService) DeleteStudy(instanceID string, studyKey string)
 		slog.Error("Error deleting collection", slog.String("studyKey", studyKey), slog.String("error", err.Error()))
 	}
 
+	err = dbService.DeleteStudyCodeListsForStudy(instanceID, studyKey)
+	if err != nil {
+		slog.Error("Error deleting study code lists", slog.String("studyKey", studyKey), slog.String("error", err.Error()))
+	}
+
 	// delete study rules for study
 	err = dbService.deleteStudyRules(instanceID, studyKey)
 	if err != nil {

--- a/pkg/study/studyengine/expressions_test.go
+++ b/pkg/study/studyengine/expressions_test.go
@@ -226,6 +226,10 @@ func (db MockStudyDBService) DeleteStudyCodeListEntry(instanceID string, studyKe
 	return nil
 }
 
+func (db MockStudyDBService) DrawStudyCode(instanceID string, studyKey string, listKey string) (string, error) {
+	return "", nil
+}
+
 func TestEvalCheckConditionForOldResponses(t *testing.T) {
 
 	testResponses := []studyTypes.SurveyResponse{

--- a/pkg/study/studyengine/types.go
+++ b/pkg/study/studyengine/types.go
@@ -38,6 +38,7 @@ type StudyDBService interface {
 	SaveResearcherMessage(instanceID string, studyKey string, message studyTypes.StudyMessage) error
 	StudyCodeListEntryExists(instanceID string, studyKey string, listKey string, code string) (bool, error)
 	DeleteStudyCodeListEntry(instanceID string, studyKey string, listKey string, code string) error
+	DrawStudyCode(instanceID string, studyKey string, listKey string) (string, error)
 }
 
 type ActionData struct {


### PR DESCRIPTION
This pull request introduces several new functionalities and improvements to the study code management system. The most significant changes include the addition of methods for deleting study code list entries, drawing study codes, and handling new actions related to study codes.

### New Methods for Study Code Management:
* Added `DeleteStudyCodeListEntries` method to delete multiple study code list entries based on `studyKey` and `listKey`.
* Added `DeleteStudyCodeListsForStudy` method to delete all study code lists for a given study.
* Added `DrawStudyCode` method to draw and delete a study code from a list.

### Updates to Study Management API:
* Modified `removeStudyCodeListEntryHandler` to handle the deletion of entire study code lists if no specific code is provided. [[1]](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4L1662-R1677) [[2]](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4R1686-R1687)

### New Action Handling in Study Engine:
* Added `DRAW_STUDY_CODE_AS_LINKING_CODE` action to draw a study code and use it as a linking code. [[1]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783R79-R80) [[2]](diffhunk://#diff-d41cc7f9a23a22f49f27038120fcd5d54e203706fc2470ac7feb466438b00783R1025-R1086)

### Interface and Mock Updates:
* Updated `StudyDBService` interface to include the new `DrawStudyCode` method.
* Added mock implementation for `DrawStudyCode` in `MockStudyDBService`.