### PR TITLE
Delete orphan task result files

### DIFF
--- a/jobs/study-timer/init.go
+++ b/jobs/study-timer/init.go
@@ -39,6 +39,11 @@ type config struct {
 
 		ExternalServices []studyengine.ExternalService `json:"external_services" yaml:"external_services"`
 	} `json:"study_configs" yaml:"study_configs"`
+
+	CleanUpConfig struct {
+		FilestorePath            string `json:"filestore_path" yaml:"filestore_path"`
+		CleanOrphanedTaskResults bool   `json:"clean_orphaned_task_results" yaml:"clean_orphaned_task_results"`
+	} `json:"clean_up_config" yaml:"clean_up_config"`
 }
 
 var conf config

--- a/pkg/db/study/taskQueue.go
+++ b/pkg/db/study/taskQueue.go
@@ -56,6 +56,23 @@ func (dbService *StudyDBService) GetTaskByID(instanceID string, taskID string) (
 	return task, err
 }
 
+func (dbService *StudyDBService) GetTaskByFilename(instanceID string, filename string) (studyTypes.Task, error) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	var task studyTypes.Task
+
+	filter := bson.M{
+		"resultFile": filename,
+	}
+
+	err := dbService.collectionTaskQueue(instanceID).FindOne(ctx, filter).Decode(&task)
+	if err != nil {
+		return task, err
+	}
+	return task, nil
+}
+
 func (dbService *StudyDBService) UpdateTaskTotalCount(instanceID string, taskID string, totalCount int) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()


### PR DESCRIPTION
## New feature for `study-timer-job`:

- If configured, it can remove orphaned task result files to optimise disk usage. Tasks are deleted after two days, so files after two days become orphaned and likely be never used by the admin-ui. 
  - To configure, add the following snippet to the config.yaml:
```
...
clean_up_config:
  filestore_path: "<path-to-storage-location>"
  clean_orphaned_task_results: true
```
  - It will scan the path at `<filestore_path>/<instance_id>` recursively for files (for each instance ID defined in the `instance_ids` array in the config.yaml)
  - for each file found, it will check if a corresponding "task" object still exists in the database
  - if no task object was found, the file will be removed