### PR TITLE
Delete old task result files by daily exporter

### DIFF
--- a/jobs/study-daily-data-export/init.go
+++ b/jobs/study-daily-data-export/init.go
@@ -61,6 +61,12 @@ type config struct {
 		PreservePreviousFiles bool                              `json:"preserve_previous_files" yaml:"preserve_previous_files"`
 		ExportTasks           []ConfidentialResponsesExportTask `json:"export_tasks" yaml:"export_tasks"`
 	} `json:"conf_resp_exports" yaml:"conf_resp_exports"`
+
+	CleanUpConfig struct {
+		CleanOrphanedTaskResults bool     `json:"clean_orphaned_task_results" yaml:"clean_orphaned_task_results"`
+		FilestoreRoot            string   `json:"filestore_root" yaml:"filestore_root"`
+		InstanceIDs              []string `json:"instance_ids" yaml:"instance_ids"`
+	} `json:"clean_up_config" yaml:"clean_up_config"`
 }
 
 var conf config

--- a/jobs/study-daily-data-export/main.go
+++ b/jobs/study-daily-data-export/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"time"
+
+	studyUtils "github.com/case-framework/case-backend/pkg/study/utils"
 )
 
 func main() {
@@ -23,6 +25,17 @@ func main() {
 	for _, rExpTask := range conf.ConfidentialResponsesExports.ExportTasks {
 		slog.Info("Running confidential responses export task", slog.String("instanceID", rExpTask.InstanceID), slog.String("studyKey", rExpTask.StudyKey), slog.String("name", rExpTask.Name))
 		runConfidentialResponsesExportsForTask(rExpTask)
+	}
+
+	// Run cleanup for orphaned task results
+	if conf.CleanUpConfig.CleanOrphanedTaskResults {
+		for _, instanceID := range conf.CleanUpConfig.InstanceIDs {
+			studyUtils.CleanUpOrphanedTaskResults(
+				instanceID,
+				studyDBService,
+				conf.CleanUpConfig.FilestoreRoot,
+			)
+		}
 	}
 
 	if err := studyDBService.DBClient.Disconnect(context.Background()); err != nil {

--- a/jobs/study-timer/main.go
+++ b/jobs/study-timer/main.go
@@ -2,14 +2,11 @@ package main
 
 import (
 	"log/slog"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 	"time"
 
 	studyservice "github.com/case-framework/case-backend/pkg/study"
 	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
+	studyUtils "github.com/case-framework/case-backend/pkg/study/utils"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -31,7 +28,11 @@ func main() {
 		}
 
 		if conf.CleanUpConfig.CleanOrphanedTaskResults {
-			cleanUpOrphanedTaskResults(instanceID)
+			studyUtils.CleanUpOrphanedTaskResults(
+				instanceID,
+				studyDBService,
+				conf.CleanUpConfig.FilestorePath,
+			)
 		}
 	}
 
@@ -67,33 +68,5 @@ func updateStudyStats(instanceID string, study studyTypes.Study) {
 	err = studyDBService.UpdateStudyStats(instanceID, study.Key, stats)
 	if err != nil {
 		slog.Error("Failed to update study stats", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
-	}
-}
-
-func cleanUpOrphanedTaskResults(instanceID string) {
-	slog.Info("Cleaning up orphaned task results (old files)", slog.String("instanceID", instanceID))
-
-	folder := path.Join(conf.CleanUpConfig.FilestorePath, instanceID)
-
-	// get all files in folder recursively
-	files, err := filepath.Glob(folder + "/**/*")
-	if err != nil {
-		slog.Error("Failed to get files", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
-		return
-	}
-
-	for _, file := range files {
-		// check if file is a task result file
-		relativeFilepath := (strings.TrimPrefix(file, path.Clean(conf.CleanUpConfig.FilestorePath)))[1:]
-
-		_, err := studyDBService.GetTaskByFilename(instanceID, relativeFilepath)
-		if err != nil {
-			slog.Info("Task for file not found, removing file", slog.String("reason", err.Error()), slog.String("instanceID", instanceID), slog.String("file", relativeFilepath))
-			err = os.Remove(file)
-			if err != nil {
-				slog.Error("Failed to remove file", slog.String("error", err.Error()), slog.String("instanceID", instanceID), slog.String("file", relativeFilepath))
-			}
-			continue
-		}
 	}
 }

--- a/pkg/study/utils/cleanup-orphaned-exports.go
+++ b/pkg/study/utils/cleanup-orphaned-exports.go
@@ -1,0 +1,43 @@
+package studyutils
+
+import (
+	"log/slog"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	studydb "github.com/case-framework/case-backend/pkg/db/study"
+)
+
+func CleanUpOrphanedTaskResults(
+	instanceID string,
+	studyDBService *studydb.StudyDBService,
+	rootPath string,
+) {
+	slog.Info("Cleaning up orphaned task results (old files)", slog.String("instanceID", instanceID))
+
+	folder := path.Join(rootPath, instanceID)
+
+	// get all files in folder recursively
+	files, err := filepath.Glob(folder + "/**/*")
+	if err != nil {
+		slog.Error("Failed to get files", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
+		return
+	}
+
+	for _, file := range files {
+		// check if file is a task result file
+		relativeFilepath := (strings.TrimPrefix(file, path.Clean(rootPath)))[1:]
+
+		_, err := studyDBService.GetTaskByFilename(instanceID, relativeFilepath)
+		if err != nil {
+			slog.Info("Task for file not found, removing file", slog.String("reason", err.Error()), slog.String("instanceID", instanceID), slog.String("file", relativeFilepath))
+			err = os.Remove(file)
+			if err != nil {
+				slog.Error("Failed to remove file", slog.String("error", err.Error()), slog.String("instanceID", instanceID), slog.String("file", relativeFilepath))
+			}
+			continue
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces a new feature for cleaning up orphaned task results and refactors existing code to utilize this new functionality. The main changes include adding a new configuration structure, updating the `main` functions in two files to call the new cleanup method, and moving the cleanup logic to a new utility file.

Key changes:

### New Feature: Cleanup Orphaned Task Results

* Added `CleanUpConfig` struct to the configuration in `jobs/study-daily-data-export/init.go` to enable cleanup settings.
* Updated `main` function in `jobs/study-daily-data-export/main.go` to run the cleanup process if enabled in the configuration.
* Updated `main` function in `jobs/study-timer/main.go` to call the new cleanup method from the utility package.

To use the new feature, add the following to the study-daily-data-export job's config:
```
...
clean_up_config:
  instance_ids:
    - my_instance_1
    - my_instance_2
  filestore_root: "./storage"
  clean_orphaned_task_results: true
```

- List all instance IDs the cleanup should run for. 
- `filestore_root`: relative path (from the "current working directory") to the root folder of the mounted storage where the task results would be written into. Most likely identical with the management-api's `filestore_path` config value.

### Code Refactoring

* Removed the old `cleanUpOrphanedTaskResults` function from `jobs/study-timer/main.go` and replaced its calls with the new utility function.
* Created a new file `pkg/study/utils/cleanup-orphaned-exports.go` to house the `CleanUpOrphanedTaskResults` function, consolidating cleanup logic in a single place.