### PR TITLE
feat: add CreateEmptyFile option to ResponseExportTask for export gen…

### DIFF
--- a/jobs/study-daily-data-export/init.go
+++ b/jobs/study-daily-data-export/init.go
@@ -22,13 +22,14 @@ const (
 )
 
 type ResponseExportTask struct {
-	InstanceID   string   `json:"instance_id" yaml:"instance_id"`
-	StudyKey     string   `json:"study_key" yaml:"study_key"`
-	SurveyKeys   []string `json:"survey_keys" yaml:"survey_keys"`
-	ExtraCtxCols []string `json:"extra_context_columns" yaml:"extra_context_columns"`
-	ExportFormat string   `json:"export_format" yaml:"export_format"`
-	Separator    string   `json:"separator" yaml:"separator"`
-	ShortKeys    bool     `json:"short_keys" yaml:"short_keys"`
+	InstanceID      string   `json:"instance_id" yaml:"instance_id"`
+	StudyKey        string   `json:"study_key" yaml:"study_key"`
+	SurveyKeys      []string `json:"survey_keys" yaml:"survey_keys"`
+	ExtraCtxCols    []string `json:"extra_context_columns" yaml:"extra_context_columns"`
+	ExportFormat    string   `json:"export_format" yaml:"export_format"`
+	Separator       string   `json:"separator" yaml:"separator"`
+	ShortKeys       bool     `json:"short_keys" yaml:"short_keys"`
+	CreateEmptyFile bool     `json:"create_empty_file" yaml:"create_empty_file"`
 }
 
 type ConfidentialResponsesExportTask struct {

--- a/jobs/study-daily-data-export/response-exporter.go
+++ b/jobs/study-daily-data-export/response-exporter.go
@@ -46,7 +46,7 @@ func runResponseExportsForTask(rExpTask ResponseExportTask) {
 				targetDate := time.Now().Add(
 					time.Duration(-(conf.ResponseExports.RetentionDays - i)) * time.Hour * 24,
 				)
-				generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser)
+				generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser, rExpTask.CreateEmptyFile)
 			}
 		}
 
@@ -54,11 +54,11 @@ func runResponseExportsForTask(rExpTask ResponseExportTask) {
 		targetDate := time.Now().Add(
 			time.Duration(-1 * time.Hour * 24),
 		)
-		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser)
+		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser, rExpTask.CreateEmptyFile)
 
 		// today
 		targetDate = time.Now()
-		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser)
+		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser, rExpTask.CreateEmptyFile)
 	}
 }
 
@@ -94,7 +94,7 @@ func initResponseParser(instanceID string, studyKey string, surveyKey string, sh
 	return
 }
 
-func generateExportForSurveyForTargetDate(instanceID string, studyKey string, surveyKey string, format string, targetDate time.Time, exportPath string, parser *surveyresponses.ResponseParser) {
+func generateExportForSurveyForTargetDate(instanceID string, studyKey string, surveyKey string, format string, targetDate time.Time, exportPath string, parser *surveyresponses.ResponseParser, createEmptyFile bool) {
 	fileName := responseFileName(targetDate, surveyKey, format)
 	responseFilePath := filepath.Join(exportPath, fileName)
 
@@ -115,7 +115,7 @@ func generateExportForSurveyForTargetDate(instanceID string, studyKey string, su
 		slog.Error("Error getting responses count", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("surveyKey", surveyKey), slog.String("error", err.Error()))
 		return
 	}
-	if count == 0 {
+	if !createEmptyFile && count == 0 {
 		slog.Debug("No responses for target date and survey key, skipping", slog.String("targetDate", targetDate.Format("2006-01-02")), slog.String("surveyKey", surveyKey))
 		return
 	}


### PR DESCRIPTION
This pull request introduces a new feature to optionally create empty files during the response export process in the `jobs/study-daily-data-export` package. The changes include adding a new field to the `ResponseExportTask` struct and modifying the relevant functions to handle this new option.

To use this new option, you can modify a response export's task config:
```
...
response_exports:
  retention_days: 40
  override_old: false
  export_tasks:
    - instance_id: "my_instance_id"
      study_key: "my_study_key"
      survey_keys: ["survey_1", "survey_2"]
      extra_context_columns: []
      export_format: "wide"
      short_keys: true
      separator: "-"
      create_empty_file: true
... 
```

New: **create_empty_file: true**

Key changes include:

* **New Field Addition:**
  - [`init.go`](diffhunk://#diff-cff3e5083b1cb739b5c107d75ad265ccc336aaecaf96723cca828f6a1589a057R32): Added the `CreateEmptyFile` boolean field to the `ResponseExportTask` struct to enable the creation of empty files during the export process.

* **Function Modifications:**
  - [`response-exporter.go`](diffhunk://#diff-47175c8a6230132dcc243b1f02cce3ba656e00ea8957dbd0929eebf46074bbefL49-R61): Updated the `runResponseExportsForTask` function to pass the `CreateEmptyFile` parameter to the `generateExportForSurveyForTargetDate` function.
  - [`response-exporter.go`](diffhunk://#diff-47175c8a6230132dcc243b1f02cce3ba656e00ea8957dbd0929eebf46074bbefL97-R97): Modified the `generateExportForSurveyForTargetDate` function to accept the `CreateEmptyFile` parameter.
  - [`response-exporter.go`](diffhunk://#diff-47175c8a6230132dcc243b1f02cce3ba656e00ea8957dbd0929eebf46074bbefL118-R118): Adjusted the logic inside `generateExportForSurveyForTargetDate` to skip file creation only if `createEmptyFile` is false and there are no responses.