### PR TITLE
implement endpoint to fetch participant state for a profile

### DIFF
--- a/services/participant-api/apihandlers/study-service.go
+++ b/services/participant-api/apihandlers/study-service.go
@@ -646,7 +646,7 @@ func (h *HttpEndpoints) getParticipantState(c *gin.Context) {
 	pid := c.DefaultQuery("pid", "")
 
 	if pid == "" {
-		slog.Error("missing required fields", slog.String("instanceID", token.InstanceID), slog.String("studyKey", studyKey), slog.String("pid", pid))
+		slog.Error("missing required fields", slog.String("instanceID", token.InstanceID), slog.String("studyKey", studyKey), slog.String("profileID", pid))
 		c.JSON(http.StatusBadRequest, gin.H{"error": "missing required fields"})
 		return
 	}
@@ -657,7 +657,7 @@ func (h *HttpEndpoints) getParticipantState(c *gin.Context) {
 		return
 	}
 
-	slog.Info("get participant state", slog.String("instanceID", token.InstanceID), slog.String("studyKey", studyKey), slog.String("subject", token.Subject), slog.String("pid", token.ProfileID))
+	slog.Info("get participant state", slog.String("instanceID", token.InstanceID), slog.String("studyKey", studyKey), slog.String("subject", token.Subject), slog.String("profileID", pid))
 
 	study, err := h.studyDBConn.GetStudy(token.InstanceID, studyKey)
 	if err != nil {


### PR DESCRIPTION
This pull request includes changes to the `services/participant-api/apihandlers/study-service.go` file, primarily to add a new API endpoint for retrieving participant state information. The changes include adding a new route and implementing the corresponding handler function.

### New API Endpoint:

* Added a new GET route for `/participant-state` in the `AddStudyServiceAPI` function. This endpoint requires a `pid` query parameter to specify the participant profile ID.

### Handler Implementation:

* Implemented the `getParticipantState` function to handle requests to the new `/participant-state` endpoint. This function performs several checks and retrieves the participant state from the database.