### PR TITLE
Endpoint to fetch confidential data

### DIFF
--- a/pkg/study/utils/confidential-response-export.go
+++ b/pkg/study/utils/confidential-response-export.go
@@ -1,0 +1,62 @@
+package studyutils
+
+import (
+	"maps"
+	"slices"
+	"strings"
+
+	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
+)
+
+type ConfidentialResponsesExportEntry struct {
+	ParticipantID string `json:"participantID"`
+	EntryID       string `json:"entryID"`
+	ResponseKey   string `json:"responseKey"`
+	Value         string `json:"value"`
+}
+
+func PrepConfidentialResponseExport(resp studyTypes.SurveyResponse, realPID string, respKeyFilter []string) []ConfidentialResponsesExportEntry {
+	parsedResp := []ConfidentialResponsesExportEntry{}
+
+	for _, r := range resp.Responses {
+		slotKey := r.Key + "-"
+
+		slots := parseSlots(r.Response, slotKey)
+		for k, v := range slots {
+			if len(respKeyFilter) > 0 && !slices.Contains(respKeyFilter, k) {
+				continue
+			}
+			parsedResp = append(parsedResp, ConfidentialResponsesExportEntry{
+				ParticipantID: realPID,
+				EntryID:       resp.ID.Hex(),
+				ResponseKey:   k,
+				Value:         v,
+			})
+		}
+	}
+
+	return parsedResp
+}
+
+func parseSlots(respItem *studyTypes.ResponseItem, slotKey string) map[string]string {
+	parsedResp := map[string]string{}
+	if respItem == nil {
+		return parsedResp
+	}
+
+	currentSlotKey := slotKey + "." + respItem.Key
+	if strings.HasSuffix(slotKey, "-") {
+		currentSlotKey = slotKey + respItem.Key
+	}
+
+	if len(respItem.Items) == 0 {
+		parsedResp[currentSlotKey] = respItem.Value
+		return parsedResp
+	}
+
+	for _, subItem := range respItem.Items {
+		r := parseSlots(subItem, currentSlotKey)
+		maps.Copy(parsedResp, r)
+	}
+	return parsedResp
+}


### PR DESCRIPTION
This pull request refactors the confidential responses export functionality by moving related types and functions to a new utility package and updating the references accordingly. Additionally, it introduces a new endpoint for fetching confidential responses.

Refactoring and code organization:

* [`jobs/study-daily-data-export/confidential-resp-exporter.go`](diffhunk://#diff-fd43ff28dd192ef60ae72574f44feb1a6a77fe838d43ca7c1c7ae9647746b97cL18-L24): Removed the `ConfidentialResponsesExportEntry` struct and related functions, and replaced them with references to `studyutils.ConfidentialResponsesExportEntry` and `studyutils.PrepConfidentialResponseExport`. [[1]](diffhunk://#diff-fd43ff28dd192ef60ae72574f44feb1a6a77fe838d43ca7c1c7ae9647746b97cL18-L24) [[2]](diffhunk://#diff-fd43ff28dd192ef60ae72574f44feb1a6a77fe838d43ca7c1c7ae9647746b97cL51-R44) [[3]](diffhunk://#diff-fd43ff28dd192ef60ae72574f44feb1a6a77fe838d43ca7c1c7ae9647746b97cL73-R66) [[4]](diffhunk://#diff-fd43ff28dd192ef60ae72574f44feb1a6a77fe838d43ca7c1c7ae9647746b97cL103-R96) [[5]](diffhunk://#diff-fd43ff28dd192ef60ae72574f44feb1a6a77fe838d43ca7c1c7ae9647746b97cL130-R123) [[6]](diffhunk://#diff-fd43ff28dd192ef60ae72574f44feb1a6a77fe838d43ca7c1c7ae9647746b97cL173-L204)
* [`pkg/study/utils/confidential-response-export.go`](diffhunk://#diff-e0e01e979ae653a19989edc96fb6adc3f2222d1217419c422d16e8b654d9495fR1-R62): Added the `ConfidentialResponsesExportEntry` struct and `PrepConfidentialResponseExport` function to the new `studyutils` package.
* [`services/management-api/apihandlers/study-management.go`](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4L2833-L2874): Updated references to use `studyutils.ConfidentialResponsesExportEntry` and `studyutils.PrepConfidentialResponseExport`. [[1]](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4L2833-L2874) [[2]](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4L2906-R2864) [[3]](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4L2924-R2882)

New functionality:

* [`services/participant-api/apihandlers/study-service.go`](diffhunk://#diff-98a1061aeb6f8a1aa2c5ff24252d4de5085d8358f661cdacf0cba99da36eab80R18): Added a new endpoint `getConfidentialResponse` to fetch confidential responses for a specific profile and key. [[1]](diffhunk://#diff-98a1061aeb6f8a1aa2c5ff24252d4de5085d8358f661cdacf0cba99da36eab80R18) [[2]](diffhunk://#diff-98a1061aeb6f8a1aa2c5ff24252d4de5085d8358f661cdacf0cba99da36eab80R55) [[3]](diffhunk://#diff-98a1061aeb6f8a1aa2c5ff24252d4de5085d8358f661cdacf0cba99da36eab80R782-R830)