### PR TITLE
Improved study email template validation

### DIFF
--- a/pkg/messaging/templates/utils.go
+++ b/pkg/messaging/templates/utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"net/url"
 	"strings"
 
 	messagingTypes "github.com/case-framework/case-backend/pkg/messaging/types"
@@ -63,4 +64,21 @@ func CheckAllTranslationsParsable(tempTranslations []messagingTypes.LocalizedTem
 		}
 	}
 	return nil
+}
+
+func SanitizeMessageType(messageType string) string {
+	trimmed := strings.TrimSpace(messageType)
+
+	// Remove quotes (both single and double)
+	noQuotes := strings.ReplaceAll(trimmed, "\"", "")
+	noQuotes = strings.ReplaceAll(noQuotes, "'", "")
+
+	// Remove carriage returns and newlines
+	noLineBreaks := strings.ReplaceAll(noQuotes, "\r", "")
+	noLineBreaks = strings.ReplaceAll(noLineBreaks, "\n", "")
+
+	// URL-encode the string to make it safe for use in URLs
+	urlSafe := url.QueryEscape(noLineBreaks)
+
+	return urlSafe
 }

--- a/services/management-api/apihandlers/messaging-service.go
+++ b/services/management-api/apihandlers/messaging-service.go
@@ -3,6 +3,7 @@ package apihandlers
 import (
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 
 	mw "github.com/case-framework/case-backend/pkg/apihelpers/middlewares"
@@ -368,6 +369,25 @@ func (h *HttpEndpoints) saveStudyMessageTemplate(c *gin.Context) {
 	studyKey := c.Param("studyKey")
 
 	// check if studyKey exists
+	studies, err := h.studyDBConn.GetStudies(token.InstanceID, "", true)
+	if err != nil {
+		slog.Error("error getting studies", slog.String("error", err.Error()))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting studies"})
+		return
+	}
+
+	notFound := true
+	for _, study := range studies {
+		if study.Key == studyKey {
+			notFound = false
+			break
+		}
+	}
+	if notFound {
+		slog.Error("study not found", slog.String("studyKey", studyKey), slog.String("instanceID", token.InstanceID))
+		c.JSON(http.StatusNotFound, gin.H{"error": "study not found"})
+		return
+	}
 
 	// parse body
 	var template messagingTypes.EmailTemplate
@@ -381,7 +401,7 @@ func (h *HttpEndpoints) saveStudyMessageTemplate(c *gin.Context) {
 	// message type mut be url safe:
 	template.MessageType = templates.SanitizeMessageType(template.MessageType)
 
-	err := emailtemplates.CheckAllTranslationsParsable(template)
+	err = emailtemplates.CheckAllTranslationsParsable(template)
 	if err != nil {
 		slog.Error("error parsing template", slog.String("error", err.Error()))
 		c.JSON(http.StatusBadRequest, gin.H{"error": "error while checking template validity"})
@@ -402,7 +422,7 @@ func (h *HttpEndpoints) saveStudyMessageTemplate(c *gin.Context) {
 func (h *HttpEndpoints) getStudyMessageTemplate(c *gin.Context) {
 	token := c.MustGet("validatedToken").(*jwthandling.ManagementUserClaims)
 	studyKey := c.Param("studyKey")
-	messageType := c.Param("messageType")
+	messageType := url.QueryEscape(c.Param("messageType"))
 
 	slog.Info("getting study message template", slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject), slog.String("studyKey", studyKey), slog.String("messageType", messageType))
 
@@ -418,7 +438,7 @@ func (h *HttpEndpoints) getStudyMessageTemplate(c *gin.Context) {
 func (h *HttpEndpoints) deleteStudyMessageTemplate(c *gin.Context) {
 	token := c.MustGet("validatedToken").(*jwthandling.ManagementUserClaims)
 	studyKey := c.Param("studyKey")
-	messageType := c.Param("messageType")
+	messageType := url.QueryEscape(c.Param("messageType"))
 
 	slog.Info("deleting study message template", slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject), slog.String("studyKey", studyKey), slog.String("messageType", messageType))
 

--- a/services/management-api/apihandlers/messaging-service.go
+++ b/services/management-api/apihandlers/messaging-service.go
@@ -398,7 +398,7 @@ func (h *HttpEndpoints) saveStudyMessageTemplate(c *gin.Context) {
 	}
 	template.StudyKey = studyKey
 
-	// message type mut be url safe:
+	// message type must be url safe:
 	template.MessageType = templates.SanitizeMessageType(template.MessageType)
 
 	err = emailtemplates.CheckAllTranslationsParsable(template)

--- a/services/management-api/apihandlers/messaging-service.go
+++ b/services/management-api/apihandlers/messaging-service.go
@@ -220,6 +220,8 @@ func (h *HttpEndpoints) saveGlobalMessageTemplate(c *gin.Context) {
 		return
 	}
 
+	template.MessageType = templates.SanitizeMessageType(template.MessageType)
+
 	err := emailtemplates.CheckAllTranslationsParsable(template)
 	if err != nil {
 		slog.Error("error parsing template", slog.String("error", err.Error()))
@@ -365,6 +367,8 @@ func (h *HttpEndpoints) saveStudyMessageTemplate(c *gin.Context) {
 	token := c.MustGet("validatedToken").(*jwthandling.ManagementUserClaims)
 	studyKey := c.Param("studyKey")
 
+	// check if studyKey exists
+
 	// parse body
 	var template messagingTypes.EmailTemplate
 	if err := c.ShouldBindJSON(&template); err != nil {
@@ -373,6 +377,9 @@ func (h *HttpEndpoints) saveStudyMessageTemplate(c *gin.Context) {
 		return
 	}
 	template.StudyKey = studyKey
+
+	// message type mut be url safe:
+	template.MessageType = templates.SanitizeMessageType(template.MessageType)
 
 	err := emailtemplates.CheckAllTranslationsParsable(template)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces improvements to the handling of `MessageType` and adds validation for `studyKey` in the messaging service. The primary changes include sanitizing `MessageType` to ensure URL safety, validating the existence of `studyKey` before processing, and applying URL encoding to `messageType` parameters in relevant endpoints.

### Improvements to `MessageType` handling:
* Introduced a new function `SanitizeMessageType` in `pkg/messaging/templates/utils.go` to sanitize `MessageType` by trimming spaces, removing quotes and line breaks, and applying URL encoding.
* Updated `saveGlobalMessageTemplate` and `saveStudyMessageTemplate` in `services/management-api/apihandlers/messaging-service.go` to sanitize `MessageType` using the new function before further processing. [[1]](diffhunk://#diff-fffef74d4da46c18dcf12a4e16d2c193faf88fc859c640ca29f609fbad50384aR224-R225) [[2]](diffhunk://#diff-fffef74d4da46c18dcf12a4e16d2c193faf88fc859c640ca29f609fbad50384aL377-R404)

### Validation for `studyKey`:
* Added logic in `saveStudyMessageTemplate` to validate if the provided `studyKey` exists in the database. Returns a `404 Not Found` error if the `studyKey` is invalid.

### URL encoding for `messageType` parameters:
* Applied `url.QueryEscape` to `messageType` parameters in `getStudyMessageTemplate` and `deleteStudyMessageTemplate` to ensure they are URL-safe. [[1]](diffhunk://#diff-fffef74d4da46c18dcf12a4e16d2c193faf88fc859c640ca29f609fbad50384aL398-R425) [[2]](diffhunk://#diff-fffef74d4da46c18dcf12a4e16d2c193faf88fc859c640ca29f609fbad50384aL414-R441)