### PR TITLE
refactor: restructure configuration for Gin and Mutual TLS settings

### DIFF
--- a/services/management-api/main.go
+++ b/services/management-api/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	// Start the server
-	slog.Info("Starting Management API on port " + conf.GinConfig.Port)
+	slog.Info("Starting Management API", slog.String("port", conf.GinConfig.Port))
 	if !conf.GinConfig.MTLS.Use {
 		err := router.Run(":" + conf.GinConfig.Port)
 		if err != nil {


### PR DESCRIPTION
This pull request refactors the configuration structure for the `management-api` service to improve organization and maintainability. The primary changes include grouping Gin-related configurations into a nested structure, integrating Mutual TLS (mTLS) settings within the Gin configuration, and updating references throughout the codebase to align with the new structure.

### Configuration Refactoring:

* Consolidated Gin-related settings (`DebugMode`, `AllowOrigins`, `Port`) into a nested `GinConfig` struct within the `Config` struct. This also includes a new nested `MTLS` struct for mTLS-specific settings. (`services/management-api/init.go`, [services/management-api/init.goL73-L86](diffhunk://#diff-51858c51b8105d269992321594e916678c1b3db308fbd2f3f67621f2d77e8064L73-L86))
* Removed redundant top-level mTLS environment variables and settings, integrating them into the new `GinConfig.MTLS` structure. (`services/management-api/init.go`, [[1]](diffhunk://#diff-51858c51b8105d269992321594e916678c1b3db308fbd2f3f67621f2d77e8064L37-L41) [[2]](diffhunk://#diff-51858c51b8105d269992321594e916678c1b3db308fbd2f3f67621f2d77e8064L220-L227)

### Code Adjustments for New Structure:

* Updated all references to Gin configurations (e.g., `GinDebugMode`, `Port`, `AllowOrigins`) to use the new `GinConfig` structure. (`services/management-api/init.go`, [[1]](diffhunk://#diff-51858c51b8105d269992321594e916678c1b3db308fbd2f3f67621f2d77e8064L108-R108) [[2]](diffhunk://#diff-51858c51b8105d269992321594e916678c1b3db308fbd2f3f67621f2d77e8064L205-R213)
* Modified the `main` function to reflect the updated structure for both Gin and mTLS configurations, including updates to server initialization and TLS setup. (`services/management-api/main.go`, [[1]](diffhunk://#diff-8fac0471b188e06384272a9adf6f3c0650115e3c8c129a77934a64e01a1b0e2cL23-R23) [[2]](diffhunk://#diff-8fac0471b188e06384272a9adf6f3c0650115e3c8c129a77934a64e01a1b0e2cL53-R79)