### PR TITLE
Update participant api

### DIFF
--- a/pkg/db/study/participants.go
+++ b/pkg/db/study/participants.go
@@ -2,6 +2,7 @@ package study
 
 import (
 	"log/slog"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -58,6 +59,7 @@ func (dbService *StudyDBService) SaveParticipantState(instanceID string, studyKe
 	defer cancel()
 
 	filter := bson.M{"participantID": pState.ParticipantID}
+	pState.ModifiedAt = time.Now().Unix()
 
 	upsert := true
 	rd := options.After

--- a/pkg/db/study/participants.go
+++ b/pkg/db/study/participants.go
@@ -1,10 +1,12 @@
 package study
 
 import (
+	"errors"
 	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"golang.org/x/net/context"
@@ -72,6 +74,36 @@ func (dbService *StudyDBService) SaveParticipantState(instanceID string, studyKe
 		ctx, filter, pState, &options,
 	).Decode(&elem)
 	return elem, err
+}
+
+func (dbService *StudyDBService) UpdateParticipantIfNotModified(instanceID string, studyKey string, pState studyTypes.Participant) (studyTypes.Participant, error) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	filter := bson.M{
+		"participantID": pState.ParticipantID,
+	}
+	if pState.ModifiedAt > 0 {
+		filter["modifiedAt"] = bson.M{"$lte": pState.ModifiedAt}
+	}
+
+	pState.ID = primitive.NilObjectID
+	pState.ModifiedAt = time.Now().Unix()
+
+	update := bson.M{"$set": pState}
+	result := dbService.collectionParticipants(instanceID, studyKey).FindOneAndUpdate(ctx, filter, update, options.FindOneAndUpdate().SetReturnDocument(options.After))
+
+	if result.Err() != nil {
+		if result.Err() == mongo.ErrNoDocuments {
+			return pState, errors.New("participant not found or has been modified since last fetch")
+		}
+		return pState, result.Err()
+	}
+	var updatedParticipant studyTypes.Participant
+	if err := result.Decode(&updatedParticipant); err != nil {
+		return pState, err
+	}
+	return updatedParticipant, nil
 }
 
 // get participant by id

--- a/pkg/permission-checker/constants.go
+++ b/pkg/permission-checker/constants.go
@@ -44,6 +44,7 @@ const (
 	ACTION_GET_FILES                  = "get-files"
 	ACTION_DELETE_FILES               = "delete-files"
 	ACTION_GET_PARTICIPANT_STATES     = "get-participant-states"
+	ACTION_EDIT_PARTICIPANT_STATES    = "edit-participant-states"
 	ACTION_GET_REPORTS                = "get-reports"
 	ACTION_DELETE_REPORTS             = "delete-reports"
 

--- a/pkg/study/types/participant.go
+++ b/pkg/study/types/participant.go
@@ -14,6 +14,7 @@ type Participant struct {
 	ID                  primitive.ObjectID   `bson:"_id,omitempty" json:"id,omitempty"`
 	ParticipantID       string               `bson:"participantID" json:"participantId"` // reference to the study specific participant ID
 	CurrentStudySession string               `bson:"currentStudySession" json:"currentStudySession"`
+	ModifiedAt          int64                `bson:"modifiedAt" json:"modifiedAt"`
 	EnteredAt           int64                `bson:"enteredAt" json:"enteredAt"`
 	StudyStatus         string               `bson:"studyStatus" json:"studyStatus"` // shows if participant is active in the study - possible values: "active", "temporary", "exited". Other values are possible and are handled like "exited" on the server.
 	Flags               map[string]string    `bson:"flags" json:"flags"`

--- a/services/management-api/apihandlers/study-management.go
+++ b/services/management-api/apihandlers/study-management.go
@@ -3414,6 +3414,8 @@ func (h *HttpEndpoints) editStudyParticipant(c *gin.Context) {
 	studyKey := c.Param("studyKey")
 	participantID := c.Param("participantID")
 
+	slog.Info("updating participant", slog.String("participantID", participantID), slog.String("studyKey", studyKey), slog.String("userID", token.Subject), slog.String("instanceID", token.InstanceID))
+
 	var req studyTypes.Participant
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Error("failed to bind request", slog.String("error", err.Error()))


### PR DESCRIPTION
This pull request introduces functionality to update participant states in a study management system while ensuring data consistency. Key changes include adding a new API endpoint, updating the participant data model, and implementing a database method to handle conditional updates.

### Backend functionality for participant updates:
* Added a new method `UpdateParticipantIfNotModified` in `StudyDBService` to update participant states only if the `ModifiedAt` timestamp has not been changed since the last fetch. This ensures data consistency during concurrent updates. (`pkg/db/study/participants.go`, [pkg/db/study/participants.goR79-R108](diffhunk://#diff-f51ad8036e23e7fbb281ae5f48ffd33948ca9704407aab31c3c7c76e6b3569a0R79-R108))
* Updated the `Participant` struct to include a `ModifiedAt` field, which tracks the last modification timestamp for each participant. (`pkg/study/types/participant.go`, [pkg/study/types/participant.goR17](diffhunk://#diff-83eaf5c8255f68d3d2fa310d994e11bf4695047403dc9ceebd3e992a0ace7eedR17))
* Modified the `SaveParticipantState` method to set the `ModifiedAt` field when saving participant data. (`pkg/db/study/participants.go`, [pkg/db/study/participants.goR64](diffhunk://#diff-f51ad8036e23e7fbb281ae5f48ffd33948ca9704407aab31c3c7c76e6b3569a0R64))

### API enhancements:
* Added a new `PUT` endpoint for editing participant states, with appropriate permission checks using the `ACTION_EDIT_PARTICIPANT_STATES` action. (`services/management-api/apihandlers/study-management.go`, [services/management-api/apihandlers/study-management.goR846-R856](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4R846-R856))
* Implemented the `editStudyParticipant` handler to process participant update requests, validate input, and call the database update method. (`services/management-api/apihandlers/study-management.go`, [services/management-api/apihandlers/study-management.goR3411-R3444](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4R3411-R3444))

### Permissions:
* Introduced a new permission action `ACTION_EDIT_PARTICIPANT_STATES` to control access to participant state modifications. (`pkg/permission-checker/constants.go`, [pkg/permission-checker/constants.goR47](diffhunk://#diff-e4a98b032259cf084219a46af98c78c4360e2bd4825377540a62131f0743d329R47))