### PR TITLE
Export import studies

### DIFF
--- a/pkg/study/types/expression.go
+++ b/pkg/study/types/expression.go
@@ -4,7 +4,7 @@ type Expression struct {
 	Name       string          `bson:"name" json:"name"` // Name of the operation to be evaluated
 	ReturnType string          `bson:"returnType,omitempty" json:"returnType,omitempty"`
 	Data       []ExpressionArg `bson:"data,omitempty" json:"data,omitempty"` // Operation arguments
-	Metadata   struct {
+	Metadata   *struct {
 		SlotTypes []*string `bson:"slotTypes,omitempty" json:"slotTypes,omitempty"`
 	} `bson:"metadata,omitempty" json:"metadata,omitempty"`
 }

--- a/services/management-api/apihandlers/study-management.go
+++ b/services/management-api/apihandlers/study-management.go
@@ -48,17 +48,6 @@ func (h *HttpEndpoints) AddStudyManagementAPI(rg *gin.RouterGroup) {
 			nil,
 			h.createStudy,
 		))
-
-		// Create a study from an export file
-		studiesGroup.POST("/import-study", mw.RequirePayload(), h.useAuthorisedHandler(
-			RequiredPermission{
-				ResourceType: pc.RESOURCE_TYPE_STUDY,
-				ResourceKeys: []string{pc.RESOURCE_KEY_STUDY_ALL},
-				Action:       pc.ACTION_CREATE_STUDY,
-			},
-			nil,
-			h.importStudyConfig,
-		))
 	}
 
 	// Study Group
@@ -120,18 +109,6 @@ func (h *HttpEndpoints) addGeneralStudyEndpoints(rg *gin.RouterGroup) {
 		nil,
 		h.exportStudyConfig,
 	)) // config=true&survey=true&rules=true
-
-	// Override study config, survey, and rules from export file
-	rg.POST("/override-study-config", h.useAuthorisedHandler(
-		RequiredPermission{
-			ResourceType:        pc.RESOURCE_TYPE_STUDY,
-			ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
-			ExtractResourceKeys: getStudyKeyFromParams,
-			Action:              pc.ACTION_CREATE_STUDY,
-		},
-		nil,
-		h.overrideStudyConfigFromFile,
-	))
 
 	rg.PUT("/is-default", mw.RequirePayload(), h.useAuthorisedHandler(
 		RequiredPermission{
@@ -1039,10 +1016,6 @@ func (h *HttpEndpoints) createStudy(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{"study": study})
 }
 
-func (h *HttpEndpoints) importStudyConfig(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, gin.H{"error": "not implemented"})
-}
-
 func (h *HttpEndpoints) getStudyProps(c *gin.Context) {
 	token := c.MustGet("validatedToken").(*jwthandling.ManagementUserClaims)
 
@@ -1173,10 +1146,6 @@ func (h *HttpEndpoints) exportStudyConfig(c *gin.Context) {
 
 	// Close the JSON object
 	configWriter.Finish()
-}
-
-func (h *HttpEndpoints) overrideStudyConfigFromFile(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, gin.H{"error": "not implemented"})
 }
 
 type StudyIsDefaultUpdateReq struct {

--- a/services/management-api/apihandlers/study-management.go
+++ b/services/management-api/apihandlers/study-management.go
@@ -47,6 +47,17 @@ func (h *HttpEndpoints) AddStudyManagementAPI(rg *gin.RouterGroup) {
 			nil,
 			h.createStudy,
 		))
+
+		// Create a study from an export file
+		studiesGroup.POST("/import-study", mw.RequirePayload(), h.useAuthorisedHandler(
+			RequiredPermission{
+				ResourceType: pc.RESOURCE_TYPE_STUDY,
+				ResourceKeys: []string{pc.RESOURCE_KEY_STUDY_ALL},
+				Action:       pc.ACTION_CREATE_STUDY,
+			},
+			nil,
+			h.importStudyConfig,
+		))
 	}
 
 	// Study Group
@@ -96,6 +107,29 @@ func (h *HttpEndpoints) addGeneralStudyEndpoints(rg *gin.RouterGroup) {
 		},
 		nil,
 		h.getStudyProps,
+	))
+
+	rg.GET("/export-config", h.useAuthorisedHandler(
+		RequiredPermission{
+			ResourceType:        pc.RESOURCE_TYPE_STUDY,
+			ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
+			ExtractResourceKeys: getStudyKeyFromParams,
+			Action:              pc.ACTION_READ_STUDY_CONFIG,
+		},
+		nil,
+		h.exportStudyConfig,
+	)) // config=true&survey=true&rules=true&codelists=true
+
+	// Override study config, survey, and rules from export file
+	rg.POST("/override-study-config", h.useAuthorisedHandler(
+		RequiredPermission{
+			ResourceType:        pc.RESOURCE_TYPE_STUDY,
+			ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
+			ExtractResourceKeys: getStudyKeyFromParams,
+			Action:              pc.ACTION_CREATE_STUDY,
+		},
+		nil,
+		h.overrideStudyConfigFromFile,
 	))
 
 	rg.PUT("/is-default", mw.RequirePayload(), h.useAuthorisedHandler(
@@ -1004,6 +1038,10 @@ func (h *HttpEndpoints) createStudy(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{"study": study})
 }
 
+func (h *HttpEndpoints) importStudyConfig(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, gin.H{"error": "not implemented"})
+}
+
 func (h *HttpEndpoints) getStudyProps(c *gin.Context) {
 	token := c.MustGet("validatedToken").(*jwthandling.ManagementUserClaims)
 
@@ -1019,6 +1057,24 @@ func (h *HttpEndpoints) getStudyProps(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"study": study})
+}
+
+func (h *HttpEndpoints) exportStudyConfig(c *gin.Context) {
+	token := c.MustGet("validatedToken").(*jwthandling.ManagementUserClaims)
+
+	studyKey := c.Param("studyKey")
+	includeConfig := c.DefaultQuery("config", "false") == "true"
+	includeSurveys := c.DefaultQuery("surveys", "false") == "true"
+	includeRules := c.DefaultQuery("rules", "false") == "true"
+	includeCodeLists := c.DefaultQuery("codelists", "false") == "true"
+
+	slog.Info("exporting study config", slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject), slog.String("studyKey", studyKey), slog.Bool("includeConfig", includeConfig), slog.Bool("includeSurveys", includeSurveys), slog.Bool("includeRules", includeRules), slog.Bool("includeCodeLists", includeCodeLists))
+
+	c.JSON(http.StatusNotImplemented, gin.H{"error": "not implemented"})
+}
+
+func (h *HttpEndpoints) overrideStudyConfigFromFile(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, gin.H{"error": "not implemented"})
 }
 
 type StudyIsDefaultUpdateReq struct {


### PR DESCRIPTION
This pull request introduces a new feature for exporting study configurations, along with some structural improvements and dependency updates. The most significant changes include adding a new API endpoint for exporting study configurations, implementing a helper struct for streaming JSON responses, and updating the `Expression` struct to use a pointer for its `Metadata` field.

### New Feature: Study Configuration Export

* **New API Endpoint**: Added a `GET /export-config` endpoint to allow authorized users to export study configurations, surveys, and rules as a JSON file. This includes query parameters to specify which parts of the study to include in the export. (`services/management-api/apihandlers/study-management.go`, [services/management-api/apihandlers/study-management.goR102-R112](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4R102-R112))
* **Helper Struct for JSON Streaming**: Introduced the `studyConfigWriter` struct to facilitate streaming JSON responses directly to the client, improving efficiency for large exports. This includes methods for writing key-value pairs and managing JSON object boundaries. (`services/management-api/apihandlers/study-management.go`, [services/management-api/apihandlers/study-management.goR1036-R1150](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4R1036-R1150))

### Structural Improvements

* **Pointer for `Metadata`**: Updated the `Metadata` field in the `Expression` struct to use a pointer, enabling better handling of optional metadata and reducing memory usage for unused fields. (`pkg/study/types/expression.go`, [pkg/study/types/expression.goL7-R7](diffhunk://#diff-7abaddc94bd00867715d984044e2676f9c5e9dcbfda2565b5b9c9063ebf4fef8L7-R7))

### Dependency Updates

* **MongoDB Primitive Import**: Added the `go.mongodb.org/mongo-driver/bson/primitive` package to support handling MongoDB object IDs in the new export functionality. (`services/management-api/apihandlers/study-management.go`, [services/management-api/apihandlers/study-management.goR23](diffhunk://#diff-1021fc6f3e5d0784378aca1a5b347f96b5e9cc46c8a31593001156d3d935a1f4R23))