### PR TITLE
feat: add functionality to merge participants in study management API

### DIFF
--- a/pkg/permission-checker/constants.go
+++ b/pkg/permission-checker/constants.go
@@ -46,6 +46,7 @@ const (
 	ACTION_CREATE_VIRTUAL_PARTICIPANT = "create-virtual-participant"
 	ACTION_EDIT_PARTICIPANT_DATA      = "edit-participant-data"
 	ACTION_GET_PARTICIPANT_STATES     = "get-participant-states"
+	ACTION_MERGE_PARTICIPANTS         = "merge-participants"
 	ACTION_GET_REPORTS                = "get-reports"
 	ACTION_DELETE_REPORTS             = "delete-reports"
 

--- a/pkg/study/study-service.go
+++ b/pkg/study/study-service.go
@@ -443,6 +443,33 @@ func OnMergeVirtualParticipant(
 	return
 }
 
+func OnForceMergeParticipants(instanceID string, studyKey string, targetParticipantID string, withParticipantID string) (result studyTypes.Participant, err error) {
+	study, err := studyDBService.GetStudy(instanceID, studyKey)
+	if err != nil {
+		slog.Error("error getting study", slog.String("error", err.Error()))
+		return
+	}
+
+	targetParticipant, err := studyDBService.GetParticipantByID(instanceID, studyKey, targetParticipantID)
+	if err != nil {
+		slog.Error("error getting target participant", slog.String("error", err.Error()))
+		return
+	}
+
+	withParticipant, err := studyDBService.GetParticipantByID(instanceID, studyKey, withParticipantID)
+	if err != nil {
+		slog.Error("error getting with participant", slog.String("error", err.Error()))
+		return
+	}
+
+	result, err = mergeParticipants(instanceID, study, targetParticipant, withParticipant)
+	if err != nil {
+		slog.Error("error merging participants", slog.String("error", err.Error()))
+		return
+	}
+	return
+}
+
 func mergeParticipants(
 	instanceID string,
 	study studyTypes.Study,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new API endpoint to merge two participants within a study.
  * Added support for a new permission to control access to participant merging actions.

* **Bug Fixes**
  * Added validation to prevent merging a participant with themselves, returning an error if attempted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->