### PR TITLE
feat: add provider field to ManagementUser and update related database queries

### DIFF
--- a/pkg/db/management-user/management-users.go
+++ b/pkg/db/management-user/management-users.go
@@ -148,6 +148,7 @@ func (dbService *ManagementUserDBService) GetAllUsers(
 			{Key: "_id", Value: 1},
 			{Key: "email", Value: 1},
 			{Key: "username", Value: 1},
+			{Key: "provider", Value: 1},
 			{Key: "isAdmin", Value: 1},
 			{Key: "imageUrl", Value: 1},
 		})
@@ -195,6 +196,7 @@ func (dbService *ManagementUserDBService) GetUsersByIDs(
 			{Key: "_id", Value: 1},
 			{Key: "email", Value: 1},
 			{Key: "username", Value: 1},
+			{Key: "provider", Value: 1},
 			{Key: "isAdmin", Value: 1},
 			{Key: "imageUrl", Value: 1},
 		})

--- a/pkg/db/management-user/management-users.go
+++ b/pkg/db/management-user/management-users.go
@@ -83,6 +83,7 @@ func (dbService *ManagementUserDBService) UpdateUser(
 	id string,
 	email string,
 	username string,
+	provider string,
 	isAdmin bool,
 	lastLogin time.Time,
 	imageURL string,
@@ -100,6 +101,7 @@ func (dbService *ManagementUserDBService) UpdateUser(
 			"$set": bson.M{
 				"email":       email,
 				"username":    username,
+				"provider":    provider,
 				"isAdmin":     isAdmin,
 				"lastLoginAt": lastLogin,
 				"imageUrl":    imageURL,

--- a/pkg/db/management-user/types.go
+++ b/pkg/db/management-user/types.go
@@ -29,6 +29,7 @@ type ManagementUser struct {
 	Sub         string             `json:"sub,omitempty" bson:"sub,omitempty"`
 	Email       string             `json:"email,omitempty" bson:"email,omitempty"`
 	Username    string             `json:"username,omitempty" bson:"username,omitempty"`
+	Provider    string             `json:"provider,omitempty" bson:"provider,omitempty"`
 	ImageURL    string             `json:"imageUrl,omitempty" bson:"imageUrl,omitempty"`
 	IsAdmin     bool               `json:"isAdmin,omitempty" bson:"isAdmin,omitempty"`
 	LastLoginAt time.Time          `json:"lastLoginAt,omitempty" bson:"lastLoginAt,omitempty"`

--- a/services/management-api/apihandlers/management-auth.go
+++ b/services/management-api/apihandlers/management-auth.go
@@ -97,7 +97,16 @@ func (h *HttpEndpoints) signInWithIdP(c *gin.Context) {
 	} else {
 		slog.Info("sign in with an existing management user", slog.String("sub", req.Sub), slog.String("instanceID", req.InstanceID), slog.String("name", req.Name), slog.String("email", req.Email))
 		// Update existing user
-		err = h.muDBConn.UpdateUser(req.InstanceID, existingUser.ID.Hex(), req.Email, req.Name, isAdmin, time.Now(), req.ImageURL)
+		err = h.muDBConn.UpdateUser(
+			req.InstanceID,
+			existingUser.ID.Hex(),
+			req.Email,
+			req.Name,
+			req.Provider,
+			isAdmin,
+			time.Now(),
+			req.ImageURL,
+		)
 		if err != nil {
 			slog.Error("could not update existing user", slog.String("sub", req.Sub), slog.String("instanceID", req.InstanceID), slog.String("name", req.Name), slog.String("email", req.Email), slog.String("error", err.Error()))
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "could not update existing user"})

--- a/services/management-api/apihandlers/management-auth.go
+++ b/services/management-api/apihandlers/management-auth.go
@@ -39,6 +39,7 @@ type SignInRequest struct {
 	Sub        string   `json:"sub"`
 	Roles      []string `json:"roles"`
 	Name       string   `json:"name"`
+	Provider   string   `json:"provider"`
 	Email      string   `json:"email"`
 	ImageURL   string   `json:"imageUrl"`
 	RenewToken string   `json:"renewToken"`
@@ -82,6 +83,7 @@ func (h *HttpEndpoints) signInWithIdP(c *gin.Context) {
 		existingUser, err = h.muDBConn.CreateUser(req.InstanceID, &mUserDB.ManagementUser{
 			Sub:         req.Sub,
 			Username:    req.Name,
+			Provider:    req.Provider,
 			Email:       req.Email,
 			ImageURL:    req.ImageURL,
 			IsAdmin:     isAdmin,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Management user records now include an Identity Provider (provider) attribute.
  * Sign-in requests can optionally specify a provider; newly created users via IDP sign-in will store it and existing users will have their provider value updated on sign-in.
  * User listings and lookups (including lightweight views) now return provider information.
  * Backward-compatible: the provider field is optional and omitted when not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->