### PR TITLE
Db migration tool

### DIFF
--- a/jobs/db-migration/README.md
+++ b/jobs/db-migration/README.md
@@ -120,6 +120,13 @@ task_configs:
     global_infos_db: true
     messaging_db: true
 
+  get_indexes:
+    study_db: ./storage/indexes/study_db.json # or false
+    participant_user_db: ./storage/indexes/participant_user_db.json # or false
+    management_user_db: ./storage/indexes/management_user_db.json # or false
+    global_infos_db: ./storage/indexes/global_infos_db.json # or false
+    messaging_db: ./storage/indexes/messaging_db.json # or false
+
   migration_tasks:
     participant_user_contact_infos_fix: false
 

--- a/jobs/db-migration/README.md
+++ b/jobs/db-migration/README.md
@@ -1,6 +1,6 @@
-# Messaging Job
+# DB Migration Job
 
-This job handles various messaging-related tasks including processing outgoing emails, scheduled messages, study messages, and researcher notifications.
+This job handles various db migration tasks including dropping and creating indexes.
 
 ## Configuration
 
@@ -18,15 +18,12 @@ The following environment variables can be used to override secrets from the con
 - `STUDY_DB_PASSWORD` - Override study database password
 - `PARTICIPANT_USER_DB_USERNAME` - Override participant user database username
 - `PARTICIPANT_USER_DB_PASSWORD` - Override participant user database password
+- `MANAGEMENT_USER_DB_USERNAME` - Override management user database username
+- `MANAGEMENT_USER_DB_PASSWORD` - Override management user database password
 - `GLOBAL_INFOS_DB_USERNAME` - Override global infos database username
 - `GLOBAL_INFOS_DB_PASSWORD` - Override global infos database password
 - `MESSAGING_DB_USERNAME` - Override messaging database username
 - `MESSAGING_DB_PASSWORD` - Override messaging database password
-
-#### Other Secrets
-
-- `SMTP_BRIDGE_API_KEY` - Override SMTP bridge API key
-- `STUDY_GLOBAL_SECRET` - Override study global secret
 
 ## Configuration File Example
 
@@ -49,6 +46,17 @@ db_configs:
     connection_str: "<connection_str>"
     username: "<env var PARTICIPANT_USER_DB_USERNAME>"
     password: "<env var PARTICIPANT_USER_DB_PASSWORD>"
+    connection_prefix: ""
+    timeout: 30
+    idle_conn_timeout: 45
+    max_pool_size: 4
+    use_no_cursor_timeout: false
+    db_name_prefix: ""
+
+  management_user_db:
+    connection_str: "<connection_str>"
+    username: "<env var MANAGEMENT_USER_DB_USERNAME>"
+    password: "<env var MANAGEMENT_USER_DB_PASSWORD>"
     connection_prefix: ""
     timeout: 30
     idle_conn_timeout: 45
@@ -95,34 +103,26 @@ instance_ids:
   - "instance1"
   - "instance2"
 
-# Messaging configuration
-messaging_configs:
-  smtp_bridge_config:
-    url: "http://localhost:8080"
-    api_key: "your_smtp_bridge_api_key"
-    request_timeout: "90s"
-
-  global_email_template_constants:
-    app_name: "Your App Name"
-    support_email: "support@example.com"
-    base_url: "https://your-app.com"
 
 # Task execution flags
-run_tasks:
-  process_outgoing_emails: true
-  schedule_handler: true
-  study_messages_handler: true
-  researcher_messages_handler: true
+task_configs:
+  drop_indexes:
+    study_db: "<all|defaults|none>"
+    participant_user_db: "<all|defaults|none>"
+    management_user_db: "<all|defaults|none>"
+    global_infos_db: "<all|defaults|none>"
+    messaging_db: "<all|defaults|none>"
 
-# Timing intervals
-intervals:
-  last_send_attempt_lock_duration: "20m"
-  login_token_ttl: "168h"
-  unsubscribe_token_ttl: "8760h"
+  create_indexes:
+    study_db: true
+    participant_user_db: true
+    management_user_db: true
+    global_infos_db: true
+    messaging_db: true
 
-# Study configuration
-study_configs:
-  global_secret: "your_global_secret_here"
+  migration_tasks:
+    participant_user_contact_infos_fix: false
+
 ```
 
 ## Usage
@@ -130,22 +130,23 @@ study_configs:
 1. Create a configuration file based on the example above
 2. Set the `CONFIG_FILE_PATH` environment variable to point to your config file
 3. Optionally set any secret override environment variables
-4. Run the messaging job
+4. Run the db migration job
 
 Example:
 
 ```bash
 export CONFIG_FILE_PATH="/path/to/your/config.yaml"
-export STUDY_DB_PASSWORD="secure_password"
-export SMTP_BRIDGE_API_KEY="your_api_key"
-./messaging
+
+./db-migration
 ```
 
 ## Tasks
 
-The messaging job can run the following tasks (controlled by the `run_tasks` configuration):
+The db migration job can run the following tasks (controlled by the `task_configs` configuration):
 
-- **Process Outgoing Emails**: Handles the queue of outgoing emails
-- **Schedule Handler**: Processes scheduled messages
-- **Study Messages Handler**: Handles automated study-related messages
-- **Researcher Messages Handler**: Processes researcher notification messages
+- **Drop Indexes**: Drops indexes from the specified databases. For each database, the following options are available:
+  - `all`: Drops all indexes
+  - `defaults`: Drops indexes with the specified name
+  - `none`: Does not drop any indexes (default)
+
+- **Create Indexes**: Creates indexes in the specified databases.

--- a/jobs/db-migration/README.md
+++ b/jobs/db-migration/README.md
@@ -33,12 +33,12 @@ logging:
   log_level: "info"
   include_src: true
   log_to_file: true
-  filename: "messaging.log"
+  filename: "db-migration.log"
   max_size: 100
   max_age: 28
   max_backups: 3
   compress_old_logs: true
-  include_build_info: true
+  include_build_info: "once"
 
 # Database configurations
 db_configs:
@@ -146,7 +146,7 @@ The db migration job can run the following tasks (controlled by the `task_config
 
 - **Drop Indexes**: Drops indexes from the specified databases. For each database, the following options are available:
   - `all`: Drops all indexes
-  - `defaults`: Drops indexes with the specified name
-  - `none`: Does not drop any indexes (default)
+  - `defaults`: Drops indexes with the specified names (defaults configured in the code)
+  - `none`: Does not drop any indexes
 
 - **Create Indexes**: Creates indexes in the specified databases.

--- a/jobs/db-migration/init.go
+++ b/jobs/db-migration/init.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -86,6 +87,29 @@ const (
 	DropIndexesModeNone     DropIndexesMode = "none"
 )
 
+func (mode DropIndexesMode) IsValid() bool {
+	switch mode {
+	case DropIndexesModeAll, DropIndexesModeDefaults, DropIndexesModeNone:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateConfig() {
+	validateDropIndexesMode("task_configs.drop_indexes.study_db", conf.TaskConfigs.DropIndexes.StudyDB)
+	validateDropIndexesMode("task_configs.drop_indexes.participant_user_db", conf.TaskConfigs.DropIndexes.ParticipantUserDB)
+	validateDropIndexesMode("task_configs.drop_indexes.management_user_db", conf.TaskConfigs.DropIndexes.ManagementUserDB)
+	validateDropIndexesMode("task_configs.drop_indexes.global_infos_db", conf.TaskConfigs.DropIndexes.GlobalInfosDB)
+	validateDropIndexesMode("task_configs.drop_indexes.messaging_db", conf.TaskConfigs.DropIndexes.MessagingDB)
+}
+
+func validateDropIndexesMode(field string, mode DropIndexesMode) {
+	if !mode.IsValid() {
+		panic(fmt.Sprintf("invalid drop indexes mode for %s: %q. Use one of: %v", field, mode, []DropIndexesMode{DropIndexesModeAll, DropIndexesModeDefaults, DropIndexesModeNone}))
+	}
+}
+
 type RequiredDBs struct {
 	StudyDB           bool
 	ParticipantUserDB bool
@@ -116,6 +140,8 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	validateConfig()
 
 	// Init logger:
 	utils.InitLogger(

--- a/jobs/db-migration/init.go
+++ b/jobs/db-migration/init.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/case-framework/case-backend/pkg/db"
+	"github.com/case-framework/case-backend/pkg/utils"
+	"gopkg.in/yaml.v2"
+
+	globalinfosDB "github.com/case-framework/case-backend/pkg/db/global-infos"
+	managementUserDB "github.com/case-framework/case-backend/pkg/db/management-user"
+	messagingDB "github.com/case-framework/case-backend/pkg/db/messaging"
+	userDB "github.com/case-framework/case-backend/pkg/db/participant-user"
+	studyDB "github.com/case-framework/case-backend/pkg/db/study"
+)
+
+// Environment variables
+const (
+	ENV_CONFIG_FILE_PATH = "CONFIG_FILE_PATH"
+
+	// Variables to override "secrets" in the config file
+	ENV_STUDY_DB_USERNAME            = "STUDY_DB_USERNAME"
+	ENV_STUDY_DB_PASSWORD            = "STUDY_DB_PASSWORD"
+	ENV_PARTICIPANT_USER_DB_USERNAME = "PARTICIPANT_USER_DB_USERNAME"
+	ENV_PARTICIPANT_USER_DB_PASSWORD = "PARTICIPANT_USER_DB_PASSWORD"
+	ENV_MANAGEMENT_USER_DB_USERNAME  = "MANAGEMENT_USER_DB_USERNAME"
+	ENV_MANAGEMENT_USER_DB_PASSWORD  = "MANAGEMENT_USER_DB_PASSWORD"
+	ENV_GLOBAL_INFOS_DB_USERNAME     = "GLOBAL_INFOS_DB_USERNAME"
+	ENV_GLOBAL_INFOS_DB_PASSWORD     = "GLOBAL_INFOS_DB_PASSWORD"
+	ENV_MESSAGING_DB_USERNAME        = "MESSAGING_DB_USERNAME"
+	ENV_MESSAGING_DB_PASSWORD        = "MESSAGING_DB_PASSWORD"
+)
+
+type config struct {
+	// Logging configs
+	Logging utils.LoggerConfig `json:"logging" yaml:"logging"`
+
+	// DB configs
+	DBConfigs struct {
+		GlobalInfosDB     db.DBConfigYaml `json:"global_infos_db" yaml:"global_infos_db"`
+		ParticipantUserDB db.DBConfigYaml `json:"participant_user_db" yaml:"participant_user_db"`
+		ManagementUserDB  db.DBConfigYaml `json:"management_user_db" yaml:"management_user_db"`
+		MessagingDB       db.DBConfigYaml `json:"messaging_db" yaml:"messaging_db"`
+		StudyDB           db.DBConfigYaml `json:"study_db" yaml:"study_db"`
+	} `json:"db_configs" yaml:"db_configs"`
+
+	InstanceIDs []string `json:"instance_ids" yaml:"instance_ids"`
+
+	// Task configurations
+	TaskConfigs TaskConfigs `json:"task_configs" yaml:"task_configs"`
+}
+
+// Explicit task configuration structs
+type TaskConfigs struct {
+	DropIndexes    DropIndexesConfig    `json:"drop_indexes" yaml:"drop_indexes"`
+	CreateIndexes  CreateIndexesConfig  `json:"create_indexes" yaml:"create_indexes"`
+	MigrationTasks MigrationTasksConfig `json:"migration_tasks" yaml:"migration_tasks"`
+}
+
+type DropIndexesConfig struct {
+	StudyDB           DropIndexesMode `json:"study_db" yaml:"study_db"`
+	ParticipantUserDB DropIndexesMode `json:"participant_user_db" yaml:"participant_user_db"`
+	ManagementUserDB  DropIndexesMode `json:"management_user_db" yaml:"management_user_db"`
+	GlobalInfosDB     DropIndexesMode `json:"global_infos_db" yaml:"global_infos_db"`
+	MessagingDB       DropIndexesMode `json:"messaging_db" yaml:"messaging_db"`
+}
+
+type CreateIndexesConfig struct {
+	StudyDB           bool `json:"study_db" yaml:"study_db"`
+	ParticipantUserDB bool `json:"participant_user_db" yaml:"participant_user_db"`
+	ManagementUserDB  bool `json:"management_user_db" yaml:"management_user_db"`
+	GlobalInfosDB     bool `json:"global_infos_db" yaml:"global_infos_db"`
+	MessagingDB       bool `json:"messaging_db" yaml:"messaging_db"`
+}
+
+type MigrationTasksConfig struct {
+	ParticipantUserContactInfosFix bool `json:"participant_user_contact_infos_fix" yaml:"participant_user_contact_infos_fix"`
+}
+
+type DropIndexesMode string
+
+const (
+	DropIndexesModeAll      DropIndexesMode = "all"
+	DropIndexesModeDefaults DropIndexesMode = "defaults"
+	DropIndexesModeNone     DropIndexesMode = "none"
+)
+
+type RequiredDBs struct {
+	StudyDB           bool
+	ParticipantUserDB bool
+	ManagementUserDB  bool
+	GlobalInfosDB     bool
+	MessagingDB       bool
+}
+
+var conf config
+
+// Database service variables - initialized only for required databases based on task config
+var (
+	participantUserDBService *userDB.ParticipantUserDBService
+	managementUserDBService  *managementUserDB.ManagementUserDBService
+	globalInfosDBService     *globalinfosDB.GlobalInfosDBService
+	messagingDBService       *messagingDB.MessagingDBService
+	studyDBService           *studyDB.StudyDBService
+)
+
+func init() {
+	// Read config from file
+	yamlFile, err := os.ReadFile(os.Getenv(ENV_CONFIG_FILE_PATH))
+	if err != nil {
+		panic(err)
+	}
+
+	err = yaml.UnmarshalStrict(yamlFile, &conf)
+	if err != nil {
+		panic(err)
+	}
+
+	// Init logger:
+	utils.InitLogger(
+		conf.Logging.LogLevel,
+		conf.Logging.IncludeSrc,
+		conf.Logging.LogToFile,
+		conf.Logging.Filename,
+		conf.Logging.MaxSize,
+		conf.Logging.MaxAge,
+		conf.Logging.MaxBackups,
+		conf.Logging.CompressOldLogs,
+		conf.Logging.IncludeBuildInfo,
+	)
+
+	// Override secrets from environment variables
+	secretsOverride()
+
+	// init db
+	initDBs()
+
+}
+
+func secretsOverride() {
+	// Override secrets from environment variables
+	if dbUsername := os.Getenv(ENV_PARTICIPANT_USER_DB_USERNAME); dbUsername != "" {
+		conf.DBConfigs.ParticipantUserDB.Username = dbUsername
+	}
+
+	if dbPassword := os.Getenv(ENV_PARTICIPANT_USER_DB_PASSWORD); dbPassword != "" {
+		conf.DBConfigs.ParticipantUserDB.Password = dbPassword
+	}
+
+	if dbUsername := os.Getenv(ENV_MANAGEMENT_USER_DB_USERNAME); dbUsername != "" {
+		conf.DBConfigs.ManagementUserDB.Username = dbUsername
+	}
+
+	if dbPassword := os.Getenv(ENV_MANAGEMENT_USER_DB_PASSWORD); dbPassword != "" {
+		conf.DBConfigs.ManagementUserDB.Password = dbPassword
+	}
+
+	if dbUsername := os.Getenv(ENV_STUDY_DB_USERNAME); dbUsername != "" {
+		conf.DBConfigs.StudyDB.Username = dbUsername
+	}
+
+	if dbPassword := os.Getenv(ENV_STUDY_DB_PASSWORD); dbPassword != "" {
+		conf.DBConfigs.StudyDB.Password = dbPassword
+	}
+
+	if dbUsername := os.Getenv(ENV_GLOBAL_INFOS_DB_USERNAME); dbUsername != "" {
+		conf.DBConfigs.GlobalInfosDB.Username = dbUsername
+	}
+
+	if dbPassword := os.Getenv(ENV_GLOBAL_INFOS_DB_PASSWORD); dbPassword != "" {
+		conf.DBConfigs.GlobalInfosDB.Password = dbPassword
+	}
+
+	if dbUsername := os.Getenv(ENV_MESSAGING_DB_USERNAME); dbUsername != "" {
+		conf.DBConfigs.MessagingDB.Username = dbUsername
+	}
+
+	if dbPassword := os.Getenv(ENV_MESSAGING_DB_PASSWORD); dbPassword != "" {
+		conf.DBConfigs.MessagingDB.Password = dbPassword
+	}
+}
+
+// getRequiredDBs determines which databases need to be connected based on task configurations
+func getRequiredDBs() RequiredDBs {
+	requiredDBs := RequiredDBs{}
+
+	dropIndexes := conf.TaskConfigs.DropIndexes
+	createIndexes := conf.TaskConfigs.CreateIndexes
+	migrationTasks := conf.TaskConfigs.MigrationTasks
+
+	// Check drop_indexes configuration
+	if dropIndexes.StudyDB != DropIndexesModeNone {
+		requiredDBs.StudyDB = true
+	}
+	if dropIndexes.ParticipantUserDB != DropIndexesModeNone {
+		requiredDBs.ParticipantUserDB = true
+	}
+	if dropIndexes.ManagementUserDB != DropIndexesModeNone {
+		requiredDBs.ManagementUserDB = true
+	}
+	if dropIndexes.GlobalInfosDB != DropIndexesModeNone {
+		requiredDBs.GlobalInfosDB = true
+	}
+	if dropIndexes.MessagingDB != DropIndexesModeNone {
+		requiredDBs.MessagingDB = true
+	}
+
+	// Check create_indexes configuration
+	if createIndexes.StudyDB {
+		requiredDBs.StudyDB = true
+	}
+	if createIndexes.ParticipantUserDB {
+		requiredDBs.ParticipantUserDB = true
+	}
+	if createIndexes.ManagementUserDB {
+		requiredDBs.ManagementUserDB = true
+	}
+	if createIndexes.GlobalInfosDB {
+		requiredDBs.GlobalInfosDB = true
+	}
+	if createIndexes.MessagingDB {
+		requiredDBs.MessagingDB = true
+	}
+
+	// Check migration_tasks configuration
+	if migrationTasks.ParticipantUserContactInfosFix {
+		requiredDBs.ParticipantUserDB = true
+	}
+
+	return requiredDBs
+}
+
+func initDBs() {
+	// Get required databases based on task configurations
+	requiredDBs := getRequiredDBs()
+
+	var err error
+
+	// Initialize only the required database services
+	if requiredDBs.ParticipantUserDB {
+		participantUserDBService, err = userDB.NewParticipantUserDBService(db.DBConfigFromYamlObj(conf.DBConfigs.ParticipantUserDB, conf.InstanceIDs))
+		if err != nil {
+			slog.Error("Error connecting to Participant User DB", slog.String("error", err.Error()))
+			panic(err)
+		}
+	}
+
+	if requiredDBs.ManagementUserDB {
+		managementUserDBService, err = managementUserDB.NewManagementUserDBService(db.DBConfigFromYamlObj(conf.DBConfigs.ManagementUserDB, conf.InstanceIDs))
+		if err != nil {
+			slog.Error("Error connecting to Management User DB", slog.String("error", err.Error()))
+			panic(err)
+		}
+	}
+
+	if requiredDBs.GlobalInfosDB {
+		globalInfosDBService, err = globalinfosDB.NewGlobalInfosDBService(db.DBConfigFromYamlObj(conf.DBConfigs.GlobalInfosDB, conf.InstanceIDs))
+		if err != nil {
+			slog.Error("Error connecting to Global Infos DB", slog.String("error", err.Error()))
+			panic(err)
+		}
+	}
+
+	if requiredDBs.MessagingDB {
+		messagingDBService, err = messagingDB.NewMessagingDBService(db.DBConfigFromYamlObj(conf.DBConfigs.MessagingDB, conf.InstanceIDs))
+		if err != nil {
+			slog.Error("Error connecting to Messaging DB", slog.String("error", err.Error()))
+			panic(err)
+		}
+	}
+
+	if requiredDBs.StudyDB {
+		studyDBService, err = studyDB.NewStudyDBService(db.DBConfigFromYamlObj(conf.DBConfigs.StudyDB, conf.InstanceIDs))
+		if err != nil {
+			slog.Error("Error connecting to Study DB", slog.String("error", err.Error()))
+			panic(err)
+		}
+	}
+
+	// Log which databases were connected
+	slog.Info("Database connections established",
+		slog.Bool("study_db", requiredDBs.StudyDB),
+		slog.Bool("participant_user_db", requiredDBs.ParticipantUserDB),
+		slog.Bool("management_user_db", requiredDBs.ManagementUserDB),
+		slog.Bool("global_infos_db", requiredDBs.GlobalInfosDB),
+		slog.Bool("messaging_db", requiredDBs.MessagingDB))
+}

--- a/jobs/db-migration/init.go
+++ b/jobs/db-migration/init.go
@@ -56,6 +56,7 @@ type config struct {
 type TaskConfigs struct {
 	DropIndexes    DropIndexesConfig    `json:"drop_indexes" yaml:"drop_indexes"`
 	CreateIndexes  CreateIndexesConfig  `json:"create_indexes" yaml:"create_indexes"`
+	GetIndexes     GetIndexesConfig     `json:"get_indexes" yaml:"get_indexes"`
 	MigrationTasks MigrationTasksConfig `json:"migration_tasks" yaml:"migration_tasks"`
 }
 
@@ -73,6 +74,14 @@ type CreateIndexesConfig struct {
 	ManagementUserDB  bool `json:"management_user_db" yaml:"management_user_db"`
 	GlobalInfosDB     bool `json:"global_infos_db" yaml:"global_infos_db"`
 	MessagingDB       bool `json:"messaging_db" yaml:"messaging_db"`
+}
+
+type GetIndexesConfig struct {
+	StudyDB           string `json:"study_db" yaml:"study_db"`
+	ParticipantUserDB string `json:"participant_user_db" yaml:"participant_user_db"`
+	ManagementUserDB  string `json:"management_user_db" yaml:"management_user_db"`
+	GlobalInfosDB     string `json:"global_infos_db" yaml:"global_infos_db"`
+	MessagingDB       string `json:"messaging_db" yaml:"messaging_db"`
 }
 
 type MigrationTasksConfig struct {
@@ -207,6 +216,26 @@ func secretsOverride() {
 	}
 }
 
+type GetIndexesDBs struct {
+	StudyDB           bool
+	ParticipantUserDB bool
+	ManagementUserDB  bool
+	GlobalInfosDB     bool
+	MessagingDB       bool
+}
+
+func shouldGetIndexesForDBs() GetIndexesDBs {
+	getIndexes := conf.TaskConfigs.GetIndexes
+
+	return GetIndexesDBs{
+		StudyDB:           getIndexes.StudyDB != "" && getIndexes.StudyDB != "false",
+		ParticipantUserDB: getIndexes.ParticipantUserDB != "" && getIndexes.ParticipantUserDB != "false",
+		ManagementUserDB:  getIndexes.ManagementUserDB != "" && getIndexes.ManagementUserDB != "false",
+		GlobalInfosDB:     getIndexes.GlobalInfosDB != "" && getIndexes.GlobalInfosDB != "false",
+		MessagingDB:       getIndexes.MessagingDB != "" && getIndexes.MessagingDB != "false",
+	}
+}
+
 // getRequiredDBs determines which databases need to be connected based on task configurations
 func getRequiredDBs() RequiredDBs {
 	requiredDBs := RequiredDBs{}
@@ -214,6 +243,7 @@ func getRequiredDBs() RequiredDBs {
 	dropIndexes := conf.TaskConfigs.DropIndexes
 	createIndexes := conf.TaskConfigs.CreateIndexes
 	migrationTasks := conf.TaskConfigs.MigrationTasks
+	shouldGetIndexes := shouldGetIndexesForDBs()
 
 	// Check drop_indexes configuration
 	if dropIndexes.StudyDB != DropIndexesModeNone {
@@ -246,6 +276,23 @@ func getRequiredDBs() RequiredDBs {
 		requiredDBs.GlobalInfosDB = true
 	}
 	if createIndexes.MessagingDB {
+		requiredDBs.MessagingDB = true
+	}
+
+	// Check get_indexes configuration
+	if shouldGetIndexes.StudyDB {
+		requiredDBs.StudyDB = true
+	}
+	if shouldGetIndexes.ParticipantUserDB {
+		requiredDBs.ParticipantUserDB = true
+	}
+	if shouldGetIndexes.ManagementUserDB {
+		requiredDBs.ManagementUserDB = true
+	}
+	if shouldGetIndexes.GlobalInfosDB {
+		requiredDBs.GlobalInfosDB = true
+	}
+	if shouldGetIndexes.MessagingDB {
 		requiredDBs.MessagingDB = true
 	}
 

--- a/jobs/db-migration/main.go
+++ b/jobs/db-migration/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/jobs/db-migration/main.go
+++ b/jobs/db-migration/main.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 func main() {
@@ -11,6 +17,8 @@ func main() {
 	createIndexes()
 
 	migrationTasks()
+
+	getIndexes()
 }
 
 func dropIndexes() {
@@ -84,5 +92,119 @@ func migrationTasks() {
 			}
 			slog.Info("Participant user contact infos fixed", slog.String("instanceID", instanceID), slog.String("duration", time.Since(start).String()))
 		}
+	}
+}
+
+func getIndexes() {
+	shouldGetIndexes := shouldGetIndexesForDBs()
+	if shouldGetIndexes.StudyDB {
+		indexes, err := studyDBService.GetIndexes()
+		if err != nil {
+			slog.Error("Error getting indexes for study DB", slog.String("error", err.Error()))
+		} else {
+			saveIndexAsJSON(indexes, conf.TaskConfigs.GetIndexes.StudyDB)
+		}
+	}
+
+	if shouldGetIndexes.ParticipantUserDB {
+		indexes, err := participantUserDBService.GetIndexes()
+		if err != nil {
+			slog.Error("Error getting indexes for participant user DB", slog.String("error", err.Error()))
+		} else {
+			saveIndexAsJSON(indexes, conf.TaskConfigs.GetIndexes.ParticipantUserDB)
+		}
+	}
+
+	if shouldGetIndexes.ManagementUserDB {
+		indexes, err := managementUserDBService.GetIndexes()
+		if err != nil {
+			slog.Error("Error getting indexes for management user DB", slog.String("error", err.Error()))
+		} else {
+			saveIndexAsJSON(indexes, conf.TaskConfigs.GetIndexes.ManagementUserDB)
+		}
+	}
+
+	if shouldGetIndexes.GlobalInfosDB {
+		indexes, err := globalInfosDBService.GetIndexes()
+		if err != nil {
+			slog.Error("Error getting indexes for global infos DB", slog.String("error", err.Error()))
+		} else {
+			saveIndexAsJSON(indexes, conf.TaskConfigs.GetIndexes.GlobalInfosDB)
+		}
+	}
+
+	if shouldGetIndexes.MessagingDB {
+		indexes, err := messagingDBService.GetIndexes()
+		if err != nil {
+			slog.Error("Error getting indexes for messaging DB", slog.String("error", err.Error()))
+		} else {
+			saveIndexAsJSON(indexes, conf.TaskConfigs.GetIndexes.MessagingDB)
+		}
+	}
+}
+
+func saveIndexAsJSON(indexes any, filename string) {
+	if filename == "" || filename == "false" {
+		slog.Warn("skipping index export: no file path configured")
+		return
+	}
+
+	normalized, err := normalizeIndexes(indexes)
+	if err != nil {
+		slog.Error("Error normalizing indexes for JSON export", slog.String("error", err.Error()))
+		normalized = indexes
+	}
+
+	jsonBytes, err := json.MarshalIndent(normalized, "", "  ")
+	if err != nil {
+		slog.Error("Error marshalling indexes to JSON", slog.String("error", err.Error()))
+		return
+	}
+	jsonBytes = append(jsonBytes, '\n')
+
+	dir := filepath.Dir(filename)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Error("Error creating directory for index export", slog.String("path", dir), slog.String("error", err.Error()))
+		return
+	}
+
+	if err := os.WriteFile(filename, jsonBytes, 0o644); err != nil {
+		slog.Error("Error writing indexes JSON to file", slog.String("path", filename), slog.String("error", err.Error()))
+		return
+	}
+
+	slog.Info("Indexes exported to JSON", slog.String("path", filename))
+}
+
+func normalizeIndexes(indexes any) (any, error) {
+	switch v := indexes.(type) {
+	case map[string]map[string][]bson.M:
+		normalized := make(map[string]map[string][]map[string]any, len(v))
+		for instanceID, collections := range v {
+			collectionMap := make(map[string][]map[string]any, len(collections))
+			for collectionName, idxList := range collections {
+				converted := make([]map[string]any, len(idxList))
+				for i, idx := range idxList {
+					converted[i] = map[string]any(idx)
+				}
+				collectionMap[collectionName] = converted
+			}
+			normalized[instanceID] = collectionMap
+		}
+		return normalized, nil
+	case map[string][]bson.M:
+		normalized := make(map[string][]map[string]any, len(v))
+		for collectionName, idxList := range v {
+			converted := make([]map[string]any, len(idxList))
+			for i, idx := range idxList {
+				converted[i] = map[string]any(idx)
+			}
+			normalized[collectionName] = converted
+		}
+		return normalized, nil
+	case map[string]any:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("unsupported index type %T", indexes)
 	}
 }

--- a/jobs/db-migration/main.go
+++ b/jobs/db-migration/main.go
@@ -1,7 +1,82 @@
 package main
 
-import "fmt"
+import "log/slog"
 
 func main() {
-	fmt.Println("Hello, World!")
+	dropIndexes()
+
+	createIndexes()
+
+	migrationTasks()
+}
+
+func dropIndexes() {
+	switch conf.TaskConfigs.DropIndexes.StudyDB {
+	case DropIndexesModeAll:
+		studyDBService.DropAllIndexes()
+	case DropIndexesModeDefaults:
+		studyDBService.DropDefaultIndexes()
+	}
+
+	switch conf.TaskConfigs.DropIndexes.ParticipantUserDB {
+	case DropIndexesModeAll:
+		participantUserDBService.DropIndexes(true)
+	case DropIndexesModeDefaults:
+		participantUserDBService.DropIndexes(false)
+	}
+
+	switch conf.TaskConfigs.DropIndexes.ManagementUserDB {
+	case DropIndexesModeAll:
+		managementUserDBService.DropIndexes(true)
+	case DropIndexesModeDefaults:
+		managementUserDBService.DropIndexes(false)
+	}
+
+	switch conf.TaskConfigs.DropIndexes.GlobalInfosDB {
+	case DropIndexesModeAll:
+		globalInfosDBService.DropIndexes(true)
+	case DropIndexesModeDefaults:
+		globalInfosDBService.DropIndexes(false)
+	}
+
+	switch conf.TaskConfigs.DropIndexes.MessagingDB {
+	case DropIndexesModeAll:
+		messagingDBService.DropIndexes(true)
+	case DropIndexesModeDefaults:
+		messagingDBService.DropIndexes(false)
+	}
+}
+
+func createIndexes() {
+	if conf.TaskConfigs.CreateIndexes.StudyDB {
+		studyDBService.CreateDefaultIndexes()
+	}
+
+	if conf.TaskConfigs.CreateIndexes.ParticipantUserDB {
+		participantUserDBService.CreateDefaultIndexes()
+	}
+
+	if conf.TaskConfigs.CreateIndexes.ManagementUserDB {
+		managementUserDBService.CreateDefaultIndexes()
+	}
+
+	if conf.TaskConfigs.CreateIndexes.GlobalInfosDB {
+		globalInfosDBService.CreateDefaultIndexes()
+	}
+
+	if conf.TaskConfigs.CreateIndexes.MessagingDB {
+		messagingDBService.CreateDefaultIndexes()
+	}
+}
+
+func migrationTasks() {
+	// Fix participant user contact infos
+	if conf.TaskConfigs.MigrationTasks.ParticipantUserContactInfosFix {
+		for _, instanceID := range participantUserDBService.InstanceIDs {
+			err := participantUserDBService.FixFieldNameForContactInfos(instanceID)
+			if err != nil {
+				slog.Error("Error fixing participant user contact infos", slog.String("instanceID", instanceID), slog.String("error", err.Error()))
+			}
+		}
+	}
 }

--- a/jobs/db-migration/main.go
+++ b/jobs/db-migration/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "log/slog"
+import (
+	"log/slog"
+	"time"
+)
 
 func main() {
 	dropIndexes()
@@ -73,10 +76,13 @@ func migrationTasks() {
 	// Fix participant user contact infos
 	if conf.TaskConfigs.MigrationTasks.ParticipantUserContactInfosFix {
 		for _, instanceID := range participantUserDBService.InstanceIDs {
+			start := time.Now()
+			slog.Info("Fixing participant user contact infos", slog.String("instanceID", instanceID))
 			err := participantUserDBService.FixFieldNameForContactInfos(instanceID)
 			if err != nil {
 				slog.Error("Error fixing participant user contact infos", slog.String("instanceID", instanceID), slog.String("error", err.Error()))
 			}
+			slog.Info("Participant user contact infos fixed", slog.String("instanceID", instanceID), slog.String("duration", time.Since(start).String()))
 		}
 	}
 }

--- a/jobs/messaging/README.md
+++ b/jobs/messaging/README.md
@@ -41,7 +41,7 @@ logging:
   max_age: 28
   max_backups: 3
   compress_old_logs: true
-  include_build_info: true
+  include_build_info: "once" # one of: never, always, once
 
 # Database configurations
 db_configs:

--- a/jobs/study-daily-data-export/README.md
+++ b/jobs/study-daily-data-export/README.md
@@ -51,7 +51,7 @@ logging:
   max_age: 28
   max_backups: 3
   compress_old_logs: true
-  include_build_info: true
+  include_build_info: "once" # one of: never, always, once
 
 # Database configurations
 db_configs:

--- a/jobs/study-daily-data-export/README.md
+++ b/jobs/study-daily-data-export/README.md
@@ -65,7 +65,6 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
 # Export path for generated files
 export_path: "/path/to/export/directory"

--- a/jobs/study-timer/README.md
+++ b/jobs/study-timer/README.md
@@ -53,7 +53,7 @@ logging:
   max_age: 28
   max_backups: 3
   compress_old_logs: true
-  include_build_info: true
+  include_build_info: "once" # one of: never, always, once
 
 # Database configurations
 db_configs:

--- a/jobs/study-timer/README.md
+++ b/jobs/study-timer/README.md
@@ -67,7 +67,6 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
 # List of instance IDs to process
 instance_ids:

--- a/jobs/user-management/README.md
+++ b/jobs/user-management/README.md
@@ -63,7 +63,7 @@ logging:
   max_age: 28
   max_backups: 3
   compress_old_logs: true
-  include_build_info: true
+  include_build_info: "once" # one of: never, always, once
 
 # Database configurations
 db_configs:

--- a/jobs/user-management/README.md
+++ b/jobs/user-management/README.md
@@ -77,7 +77,6 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
   global_infos_db:
     connection_str: "<connection_str>"
@@ -89,7 +88,6 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
   messaging_db:
     connection_str: "<connection_str>"
@@ -101,7 +99,6 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
   study_db:
     connection_str: "<connection_str>"
@@ -113,7 +110,6 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
 # List of instance IDs to process
 instance_ids:

--- a/pkg/db/global-infos/blocked-jwts.go
+++ b/pkg/db/global-infos/blocked-jwts.go
@@ -76,7 +76,7 @@ func (dbService *GlobalInfosDBService) AddBlockedJwt(token string, expiresAt tim
 
 	_, err := dbService.collectionBlockedJwts().InsertOne(ctx, blockedJwt)
 	if err != nil {
-		slog.Error("Error adding JWT to blocked list", slog.String("error", err.Error()), slog.String("token", token))
+		slog.Error("Error adding JWT to blocked list", slog.String("error", err.Error()))
 		return err
 	}
 
@@ -94,7 +94,7 @@ func (dbService *GlobalInfosDBService) IsJwtBlocked(token string) bool {
 	// Use CountDocuments with limit 1 for a faster existence check
 	count, err := dbService.collectionBlockedJwts().CountDocuments(ctx, filter, options.Count().SetLimit(1))
 	if err != nil {
-		slog.Error("Error checking if JWT is blocked", slog.String("error", err.Error()), slog.String("token", token))
+		slog.Error("Error checking if JWT is blocked", slog.String("error", err.Error()))
 		return false
 	}
 	return count > 0

--- a/pkg/db/global-infos/blocked-jwts.go
+++ b/pkg/db/global-infos/blocked-jwts.go
@@ -41,7 +41,7 @@ func (dbService *GlobalInfosDBService) DropIndexForBlockedJwtsCollection(dropAll
 		}
 	} else {
 		for _, index := range indexesForBlockedJwtsCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for blocked jwts collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/global-infos/db.go
+++ b/pkg/db/global-infos/db.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/case-framework/case-backend/pkg/db"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -88,4 +89,24 @@ func (dbService *GlobalInfosDBService) CreateDefaultIndexes() {
 	dbService.CreateDefaultIndexesForTemptokensCollection()
 	slog.Info("Default indexes created for global infos DB", slog.String("duration", time.Since(start).String()))
 
+}
+
+func (dbService *GlobalInfosDBService) GetIndexes() (map[string][]bson.M, error) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	blockedJwts, err := db.ListCollectionIndexes(ctx, dbService.collectionBlockedJwts())
+	if err != nil {
+		return nil, err
+	}
+
+	tempTokens, err := db.ListCollectionIndexes(ctx, dbService.collectionTemptokens())
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string][]bson.M{
+		COLLECTION_NAME_BLOCKED_JWTS: blockedJwts,
+		COLLECTION_NAME_TEMPTOKENS:   tempTokens,
+	}, nil
 }

--- a/pkg/db/global-infos/db.go
+++ b/pkg/db/global-infos/db.go
@@ -2,6 +2,7 @@ package globalinfos
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/case-framework/case-backend/pkg/db"
@@ -73,11 +74,18 @@ func (dbService *GlobalInfosDBService) collectionBlockedJwts() *mongo.Collection
 }
 
 func (dbService *GlobalInfosDBService) DropIndexes(all bool) {
+	start := time.Now()
+	slog.Info("Dropping indexes for global infos DB")
 	dbService.DropIndexForBlockedJwtsCollection(all)
 	dbService.DropIndexForTemptokensCollection(all)
+	slog.Info("Indexes dropped for global infos DB", slog.String("duration", time.Since(start).String()))
 }
 
 func (dbService *GlobalInfosDBService) CreateDefaultIndexes() {
+	start := time.Now()
+	slog.Info("Creating default indexes for global infos DB")
 	dbService.CreateDefaultIndexesForBlockedJwtsCollection()
 	dbService.CreateDefaultIndexesForTemptokensCollection()
+	slog.Info("Default indexes created for global infos DB", slog.String("duration", time.Since(start).String()))
+
 }

--- a/pkg/db/global-infos/temptoken.go
+++ b/pkg/db/global-infos/temptoken.go
@@ -47,7 +47,7 @@ func (dbService *GlobalInfosDBService) DropIndexForTemptokensCollection(dropAll 
 		}
 	} else {
 		for _, index := range indexesForTemptokensCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for temptokens collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/global-infos/temptoken.go
+++ b/pkg/db/global-infos/temptoken.go
@@ -21,7 +21,7 @@ var indexesForTemptokensCollection = []mongo.IndexModel{
 			{Key: "instanceID", Value: 1},
 			{Key: "purpose", Value: 1},
 		},
-		Options: options.Index().SetName("userID_instanceID_purpose_1"),
+		Options: options.Index().SetName("userID_1_instanceID_1_purpose_1"),
 	},
 	{
 		Keys: bson.D{

--- a/pkg/db/management-user/app-roles.go
+++ b/pkg/db/management-user/app-roles.go
@@ -25,11 +25,11 @@ func (dbService *ManagementUserDBService) collectionAppRoleTemplates(instanceID 
 var indexesForAppRolesCollection = []mongo.IndexModel{
 	{
 		Keys:    bson.D{{Key: "subjectId", Value: 1}},
-		Options: options.Index().SetName("app_roles_subjectId_1"),
+		Options: options.Index().SetName("subjectId_1"),
 	},
 	{
 		Keys:    bson.D{{Key: "appName", Value: 1}},
-		Options: options.Index().SetName("app_roles_appName_1"),
+		Options: options.Index().SetName("appName_1"),
 	},
 	{
 		Keys: bson.D{
@@ -38,7 +38,7 @@ var indexesForAppRolesCollection = []mongo.IndexModel{
 			{Key: "appName", Value: 1},
 			{Key: "role", Value: 1},
 		},
-		Options: options.Index().SetName("uniq_subjectType_subjectId_appName_role").SetUnique(true),
+		Options: options.Index().SetName("uniq_subjectType_1_subjectId_1_appName_1_role_1").SetUnique(true),
 	},
 }
 
@@ -78,11 +78,11 @@ func (dbService *ManagementUserDBService) CreateDefaultIndexesForAppRolesCollect
 var indexesForAppRoleTemplatesCollection = []mongo.IndexModel{
 	{
 		Keys:    bson.D{{Key: "appName", Value: 1}, {Key: "role", Value: 1}},
-		Options: options.Index().SetName("uniq_appName_role").SetUnique(true),
+		Options: options.Index().SetName("uniq_appName_1_role_1").SetUnique(true),
 	},
 	{
 		Keys:    bson.D{{Key: "appName", Value: 1}},
-		Options: options.Index().SetName("app_role_templates_appName_1"),
+		Options: options.Index().SetName("appName_1"),
 	},
 }
 

--- a/pkg/db/management-user/app-roles.go
+++ b/pkg/db/management-user/app-roles.go
@@ -52,7 +52,7 @@ func (dbService *ManagementUserDBService) DropIndexForAppRolesCollection(instanc
 		}
 	} else {
 		for _, index := range indexesForAppRolesCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for app roles collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}
@@ -96,7 +96,7 @@ func (dbService *ManagementUserDBService) DropIndexForAppRoleTemplatesCollection
 		}
 	} else {
 		for _, index := range indexesForAppRoleTemplatesCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for app role templates collection: ", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/management-user/app-roles.go
+++ b/pkg/db/management-user/app-roles.go
@@ -2,6 +2,7 @@ package managementuser
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -21,52 +22,101 @@ func (dbService *ManagementUserDBService) collectionAppRoleTemplates(instanceID 
 	return dbService.DBClient.Database(dbService.getDBName(instanceID)).Collection(COLLECTION_NAME_APP_ROLE_TEMPLATES)
 }
 
-func (dbService *ManagementUserDBService) createIndexForAppRoles(instanceID string) error {
-	ctx, cancel := dbService.getContext()
-	defer cancel()
-
-	if _, err := dbService.collectionAppRoles(instanceID).Indexes().DropAll(ctx); err != nil {
-		slog.Error("Error dropping indexes for app roles: ", slog.String("error", err.Error()))
-	}
-
-	idx := []mongo.IndexModel{
-		{
-			Keys:    bson.D{{Key: "subjectId", Value: 1}},
-			Options: options.Index().SetName("app_roles_subjectId_1"),
+var indexesForAppRolesCollection = []mongo.IndexModel{
+	{
+		Keys:    bson.D{{Key: "subjectId", Value: 1}},
+		Options: options.Index().SetName("app_roles_subjectId_1"),
+	},
+	{
+		Keys:    bson.D{{Key: "appName", Value: 1}},
+		Options: options.Index().SetName("app_roles_appName_1"),
+	},
+	{
+		Keys: bson.D{
+			{Key: "subjectType", Value: 1},
+			{Key: "subjectId", Value: 1},
+			{Key: "appName", Value: 1},
+			{Key: "role", Value: 1},
 		},
-		{
-			Keys:    bson.D{{Key: "appName", Value: 1}},
-			Options: options.Index().SetName("app_roles_appName_1"),
-		},
-		{
-			Keys: bson.D{
-				{Key: "subjectType", Value: 1},
-				{Key: "subjectId", Value: 1},
-				{Key: "appName", Value: 1},
-				{Key: "role", Value: 1},
-			},
-			Options: options.Index().SetName("uniq_subjectType_subjectId_appName_role").SetUnique(true),
-		},
-	}
-	_, err := dbService.collectionAppRoles(instanceID).Indexes().CreateMany(ctx, idx)
-	return err
+		Options: options.Index().SetName("uniq_subjectType_subjectId_appName_role").SetUnique(true),
+	},
 }
 
-func (dbService *ManagementUserDBService) createIndexForAppRoleTemplates(instanceID string) error {
+func (dbService *ManagementUserDBService) DropIndexForAppRolesCollection(instanceID string, dropAll bool) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
-	idx := []mongo.IndexModel{
-		{
-			Keys:    bson.D{{Key: "appName", Value: 1}, {Key: "role", Value: 1}},
-			Options: options.Index().SetName("uniq_appName_role").SetUnique(true),
-		},
-		{
-			Keys:    bson.D{{Key: "appName", Value: 1}},
-			Options: options.Index().SetName("app_role_templates_appName_1"),
-		},
+	if dropAll {
+		_, err := dbService.collectionAppRoles(instanceID).Indexes().DropAll(ctx)
+		if err != nil {
+			slog.Error("Error dropping all indexes for app roles", slog.String("error", err.Error()))
+		}
+	} else {
+		for _, index := range indexesForAppRolesCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for app roles collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
+			indexName := *index.Options.Name
+			_, err := dbService.collectionAppRoles(instanceID).Indexes().DropOne(ctx, indexName)
+			if err != nil {
+				slog.Error("Error dropping index for app roles", slog.String("error", err.Error()), slog.String("indexName", indexName))
+			}
+		}
 	}
-	_, err := dbService.collectionAppRoleTemplates(instanceID).Indexes().CreateMany(ctx, idx)
-	return err
+}
+
+func (dbService *ManagementUserDBService) CreateDefaultIndexesForAppRolesCollection(instanceID string) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	_, err := dbService.collectionAppRoles(instanceID).Indexes().CreateMany(ctx, indexesForAppRolesCollection)
+	if err != nil {
+		slog.Error("Error creating index for app roles", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
+	}
+}
+
+var indexesForAppRoleTemplatesCollection = []mongo.IndexModel{
+	{
+		Keys:    bson.D{{Key: "appName", Value: 1}, {Key: "role", Value: 1}},
+		Options: options.Index().SetName("uniq_appName_role").SetUnique(true),
+	},
+	{
+		Keys:    bson.D{{Key: "appName", Value: 1}},
+		Options: options.Index().SetName("app_role_templates_appName_1"),
+	},
+}
+
+func (dbService *ManagementUserDBService) DropIndexForAppRoleTemplatesCollection(instanceID string, dropAll bool) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+	if dropAll {
+		_, err := dbService.collectionAppRoleTemplates(instanceID).Indexes().DropAll(ctx)
+		if err != nil {
+			slog.Error("Error dropping all indexes for app role templates", slog.String("error", err.Error()))
+		}
+	} else {
+		for _, index := range indexesForAppRoleTemplatesCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for app role templates collection: ", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
+			indexName := *index.Options.Name
+			_, err := dbService.collectionAppRoleTemplates(instanceID).Indexes().DropOne(ctx, indexName)
+			if err != nil {
+				slog.Error("Error dropping index for app role templates", slog.String("error", err.Error()), slog.String("indexName", indexName))
+			}
+		}
+	}
+}
+
+func (dbService *ManagementUserDBService) CreateDefaultIndexesForAppRoleTemplatesCollection(instanceID string) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	_, err := dbService.collectionAppRoleTemplates(instanceID).Indexes().CreateMany(ctx, indexesForAppRoleTemplatesCollection)
+	if err != nil {
+		slog.Error("Error creating index for app role templates", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
+	}
 }
 
 /// App role templates

--- a/pkg/db/management-user/db.go
+++ b/pkg/db/management-user/db.go
@@ -2,6 +2,7 @@ package managementuser
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/case-framework/case-backend/pkg/db"
@@ -83,22 +84,28 @@ func (dbService *ManagementUserDBService) getContext() (ctx context.Context, can
 
 func (dbService *ManagementUserDBService) CreateDefaultIndexes() {
 	for _, instanceID := range dbService.InstanceIDs {
+		start := time.Now()
+		slog.Info("Creating default indexes for management user DB", slog.String("instanceID", instanceID))
 		dbService.CreateDefaultIndexesForAppRolesCollection(instanceID)
 		dbService.CreateDefaultIndexesForAppRoleTemplatesCollection(instanceID)
 		dbService.CreateDefaultIndexesForManagementUsersCollection(instanceID)
 		dbService.CreateDefaultIndexesForPermissionsCollection(instanceID)
 		dbService.CreateDefaultIndexesForServiceUserAPIKeysCollection(instanceID)
 		dbService.CreateDefaultIndexesForSessionsCollection(instanceID)
+		slog.Info("Default indexes created for management user DB", slog.String("instanceID", instanceID), slog.String("duration", time.Since(start).String()))
 	}
 }
 
 func (dbService *ManagementUserDBService) DropIndexes(dropAll bool) {
 	for _, instanceID := range dbService.InstanceIDs {
+		start := time.Now()
+		slog.Info("Dropping indexes for management user DB", slog.String("instanceID", instanceID))
 		dbService.DropIndexForAppRolesCollection(instanceID, dropAll)
 		dbService.DropIndexForAppRoleTemplatesCollection(instanceID, dropAll)
 		dbService.DropIndexForManagementUsersCollection(instanceID, dropAll)
 		dbService.DropIndexForPermissionsCollection(instanceID, dropAll)
 		dbService.DropIndexForServiceUserAPIKeysCollection(instanceID, dropAll)
 		dbService.DropIndexForSessionsCollection(instanceID, dropAll)
+		slog.Info("Indexes dropped for management user DB", slog.String("instanceID", instanceID), slog.String("duration", time.Since(start).String()))
 	}
 }

--- a/pkg/db/management-user/management-users.go
+++ b/pkg/db/management-user/management-users.go
@@ -25,18 +25,18 @@ func (dbService *ManagementUserDBService) DropIndexForManagementUsersCollection(
 	if dropAll {
 		_, err := dbService.collectionManagementUsers(instanceID).Indexes().DropAll(ctx)
 		if err != nil {
-			slog.Error("Error dropping all indexes for management users: ", slog.String("error", err.Error()))
+			slog.Error("Error dropping all indexes for management users", slog.String("error", err.Error()))
 		}
 	} else {
 		for _, index := range indexesForManagementUsersCollection {
 			if index.Options.Name == nil {
-				slog.Error("Index name is nil for management users collection: ", slog.String("index", fmt.Sprintf("%+v", index)))
+				slog.Error("Index name is nil for management users collection", slog.String("index", fmt.Sprintf("%+v", index)), slog.String("instanceID", instanceID))
 				continue
 			}
 			indexName := *index.Options.Name
 			_, err := dbService.collectionManagementUsers(instanceID).Indexes().DropOne(ctx, indexName)
 			if err != nil {
-				slog.Error("Error dropping index for management users: ", slog.String("error", err.Error()), slog.String("indexName", indexName))
+				slog.Error("Error dropping index for management users", slog.String("error", err.Error()), slog.String("indexName", indexName), slog.String("instanceID", instanceID))
 			}
 		}
 	}
@@ -47,7 +47,7 @@ func (dbService *ManagementUserDBService) CreateDefaultIndexesForManagementUsers
 	defer cancel()
 	_, err := dbService.collectionManagementUsers(instanceID).Indexes().CreateMany(ctx, indexesForManagementUsersCollection)
 	if err != nil {
-		slog.Error("Error creating index for management users: ", slog.String("error", err.Error()))
+		slog.Error("Error creating index for management users", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
 	}
 }
 

--- a/pkg/db/management-user/management-users.go
+++ b/pkg/db/management-user/management-users.go
@@ -29,7 +29,7 @@ func (dbService *ManagementUserDBService) DropIndexForManagementUsersCollection(
 		}
 	} else {
 		for _, index := range indexesForManagementUsersCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for management users collection", slog.String("index", fmt.Sprintf("%+v", index)), slog.String("instanceID", instanceID))
 				continue
 			}

--- a/pkg/db/management-user/management-users.go
+++ b/pkg/db/management-user/management-users.go
@@ -1,6 +1,7 @@
 package managementuser
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -10,22 +11,44 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-func (dbService *ManagementUserDBService) createIndexForManagementUsers(instanceID string) error {
+var indexesForManagementUsersCollection = []mongo.IndexModel{
+	{
+		Keys:    bson.D{{Key: "sub", Value: 1}},
+		Options: options.Index().SetUnique(true).SetName("uniq_sub"),
+	},
+}
+
+func (dbService *ManagementUserDBService) DropIndexForManagementUsersCollection(instanceID string, dropAll bool) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
-	if _, err := dbService.collectionManagementUsers(instanceID).Indexes().DropAll(ctx); err != nil {
-		slog.Error("Error dropping indexes for management users: ", slog.String("error", err.Error()))
+	if dropAll {
+		_, err := dbService.collectionManagementUsers(instanceID).Indexes().DropAll(ctx)
+		if err != nil {
+			slog.Error("Error dropping all indexes for management users: ", slog.String("error", err.Error()))
+		}
+	} else {
+		for _, index := range indexesForManagementUsersCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for management users collection: ", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
+			indexName := *index.Options.Name
+			_, err := dbService.collectionManagementUsers(instanceID).Indexes().DropOne(ctx, indexName)
+			if err != nil {
+				slog.Error("Error dropping index for management users: ", slog.String("error", err.Error()), slog.String("indexName", indexName))
+			}
+		}
 	}
+}
 
-	_, err := dbService.collectionManagementUsers(instanceID).Indexes().CreateOne(
-		ctx,
-		mongo.IndexModel{
-			Keys:    bson.D{{Key: "sub", Value: 1}},
-			Options: options.Index().SetUnique(true),
-		},
-	)
-	return err
+func (dbService *ManagementUserDBService) CreateDefaultIndexesForManagementUsersCollection(instanceID string) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+	_, err := dbService.collectionManagementUsers(instanceID).Indexes().CreateMany(ctx, indexesForManagementUsersCollection)
+	if err != nil {
+		slog.Error("Error creating index for management users: ", slog.String("error", err.Error()))
+	}
 }
 
 func (dbService *ManagementUserDBService) CreateUser(

--- a/pkg/db/management-user/management-users.go
+++ b/pkg/db/management-user/management-users.go
@@ -14,7 +14,7 @@ import (
 var indexesForManagementUsersCollection = []mongo.IndexModel{
 	{
 		Keys:    bson.D{{Key: "sub", Value: 1}},
-		Options: options.Index().SetUnique(true).SetName("uniq_sub"),
+		Options: options.Index().SetUnique(true).SetName("uniq_sub_1"),
 	},
 }
 

--- a/pkg/db/management-user/permissions.go
+++ b/pkg/db/management-user/permissions.go
@@ -19,7 +19,7 @@ var indexesForPermissionsCollection = []mongo.IndexModel{
 			{Key: "resourceKey", Value: 1},
 			{Key: "action", Value: 1},
 		},
-		Options: options.Index().SetName("uniq_subjectId_subjectType_resourceType_resourceKey_action"),
+		Options: options.Index().SetName("subjectId_1_subjectType_1_resourceType_1_resourceKey_1_action_1"),
 	},
 }
 

--- a/pkg/db/management-user/permissions.go
+++ b/pkg/db/management-user/permissions.go
@@ -34,7 +34,7 @@ func (dbService *ManagementUserDBService) DropIndexForPermissionsCollection(inst
 		}
 	} else {
 		for _, index := range indexesForPermissionsCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for permissions collection: ", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/management-user/service-users.go
+++ b/pkg/db/management-user/service-users.go
@@ -1,6 +1,7 @@
 package managementuser
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -86,7 +87,8 @@ func (dbService *ManagementUserDBService) CreateServiceUser(instanceID string, l
 	}
 
 	if result.InsertedID == nil {
-		slog.Error("Error creating service user", slog.String("error", "InsertedID is nil"))
+		err = errors.New("InsertedID is nil")
+		slog.Error("Error creating service user", slog.String("error", err.Error()))
 		return nil, err
 	}
 

--- a/pkg/db/management-user/service-users.go
+++ b/pkg/db/management-user/service-users.go
@@ -46,7 +46,7 @@ func (dbService *ManagementUserDBService) DropIndexForServiceUserAPIKeysCollecti
 		}
 	} else {
 		for _, index := range indexesForServiceUserAPIKeysCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for service user API keys collection: ", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/management-user/sessions.go
+++ b/pkg/db/management-user/sessions.go
@@ -33,7 +33,7 @@ func (dbService *ManagementUserDBService) DropIndexForSessionsCollection(instanc
 		}
 	} else {
 		for _, index := range indexesForSessionsCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for sessions collection: ", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/management-user/sessions.go
+++ b/pkg/db/management-user/sessions.go
@@ -1,6 +1,7 @@
 package managementuser
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -14,23 +15,45 @@ func (dbService *ManagementUserDBService) collectionSessions(instanceID string) 
 	return dbService.DBClient.Database(dbService.getDBName(instanceID)).Collection(COLLECTION_NAME_SESSIONS)
 }
 
-func (dbService *ManagementUserDBService) createIndexForSessions(instanceID string) error {
+var indexesForSessionsCollection = []mongo.IndexModel{
+	{
+		Keys:    bson.D{{Key: "createdAt", Value: 1}},
+		Options: options.Index().SetExpireAfterSeconds(REMOVE_SESSIONS_AFTER).SetName("createdAt_1"),
+	},
+}
+
+func (dbService *ManagementUserDBService) DropIndexForSessionsCollection(instanceID string, dropAll bool) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
-	if _, err := dbService.collectionSessions(instanceID).Indexes().DropAll(ctx); err != nil {
-		slog.Error("Error dropping indexes for sessions", slog.String("error", err.Error()))
+	if dropAll {
+		_, err := dbService.collectionSessions(instanceID).Indexes().DropAll(ctx)
+		if err != nil {
+			slog.Error("Error dropping all indexes for sessions", slog.String("error", err.Error()))
+		}
+	} else {
+		for _, index := range indexesForSessionsCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for sessions collection: ", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
+			indexName := *index.Options.Name
+			_, err := dbService.collectionSessions(instanceID).Indexes().DropOne(ctx, indexName)
+			if err != nil {
+				slog.Error("Error dropping index for sessions", slog.String("error", err.Error()), slog.String("indexName", indexName))
+			}
+		}
 	}
+}
 
-	_, err := dbService.collectionSessions(instanceID).Indexes().CreateMany(
-		ctx, []mongo.IndexModel{
-			{
-				Keys:    bson.D{{Key: "createdAt", Value: 1}},
-				Options: options.Index().SetExpireAfterSeconds(REMOVE_SESSIONS_AFTER),
-			},
-		},
-	)
-	return err
+func (dbService *ManagementUserDBService) CreateDefaultIndexesForSessionsCollection(instanceID string) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	_, err := dbService.collectionSessions(instanceID).Indexes().CreateMany(ctx, indexesForSessionsCollection)
+	if err != nil {
+		slog.Error("Error creating index for sessions: ", slog.String("error", err.Error()))
+	}
 }
 
 // Session represents a user session, created when a user logs in

--- a/pkg/db/management-user/sessions.go
+++ b/pkg/db/management-user/sessions.go
@@ -91,7 +91,7 @@ func (dbService *ManagementUserDBService) GetSession(
 	if err != nil {
 		return nil, err
 	}
-	err = dbService.collectionSessions(instanceID).FindOne(ctx, primitive.M{"_id": objID}).Decode(&session)
+	err = dbService.collectionSessions(instanceID).FindOne(ctx, bson.M{"_id": objID}).Decode(&session)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (dbService *ManagementUserDBService) DeleteSession(
 	if err != nil {
 		return err
 	}
-	_, err = dbService.collectionSessions(instanceID).DeleteOne(ctx, primitive.M{"_id": objID})
+	_, err = dbService.collectionSessions(instanceID).DeleteOne(ctx, bson.M{"_id": objID})
 	return err
 }
 
@@ -122,6 +122,6 @@ func (dbService *ManagementUserDBService) DeleteSessionsByUserID(
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
-	_, err := dbService.collectionSessions(instanceID).DeleteMany(ctx, primitive.M{"userId": userID})
+	_, err := dbService.collectionSessions(instanceID).DeleteMany(ctx, bson.M{"userId": userID})
 	return err
 }

--- a/pkg/db/messaging/email-templates.go
+++ b/pkg/db/messaging/email-templates.go
@@ -18,7 +18,7 @@ var indexesForEmailTemplatesCollection = []mongo.IndexModel{
 			{Key: "messageType", Value: 1},
 			{Key: "studyKey", Value: 1},
 		},
-		Options: options.Index().SetUnique(true).SetName("messageType_studyKey_1"),
+		Options: options.Index().SetUnique(true).SetName("messageType_1_studyKey_1"),
 	},
 }
 

--- a/pkg/db/messaging/email-templates.go
+++ b/pkg/db/messaging/email-templates.go
@@ -1,12 +1,59 @@
 package messaging
 
 import (
+	"fmt"
+	"log/slog"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	messagingTypes "github.com/case-framework/case-backend/pkg/messaging/types"
 )
+
+var indexesForEmailTemplatesCollection = []mongo.IndexModel{
+	{
+		Keys: bson.D{
+			{Key: "messageType", Value: 1},
+			{Key: "studyKey", Value: 1},
+		},
+		Options: options.Index().SetUnique(true).SetName("messageType_studyKey_1"),
+	},
+}
+
+func (messagingDBService *MessagingDBService) DropIndexForEmailTemplatesCollection(instanceID string, dropAll bool) {
+	ctx, cancel := messagingDBService.getContext()
+	defer cancel()
+
+	if dropAll {
+		_, err := messagingDBService.collectionEmailTemplates(instanceID).Indexes().DropAll(ctx)
+		if err != nil {
+			slog.Error("Error dropping all indexes for email templates", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
+		}
+	} else {
+		for _, index := range indexesForEmailTemplatesCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for email templates collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
+			indexName := *index.Options.Name
+			_, err := messagingDBService.collectionEmailTemplates(instanceID).Indexes().DropOne(ctx, indexName)
+			if err != nil {
+				slog.Error("Error dropping index for email templates", slog.String("error", err.Error()), slog.String("instanceID", instanceID), slog.String("indexName", indexName))
+			}
+		}
+	}
+}
+
+func (messagingDBService *MessagingDBService) CreateDefaultIndexesForEmailTemplatesCollection(instanceID string) {
+	ctx, cancel := messagingDBService.getContext()
+	defer cancel()
+	_, err := messagingDBService.collectionEmailTemplates(instanceID).Indexes().CreateMany(ctx, indexesForEmailTemplatesCollection)
+	if err != nil {
+		slog.Error("Error creating index for email templates", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
+	}
+}
 
 // find all email templates with study key empty
 func (messagingDBService *MessagingDBService) GetGlobalEmailTemplates(instanceID string) ([]messagingTypes.EmailTemplate, error) {

--- a/pkg/db/messaging/email-templates.go
+++ b/pkg/db/messaging/email-templates.go
@@ -33,7 +33,7 @@ func (messagingDBService *MessagingDBService) DropIndexForEmailTemplatesCollecti
 		}
 	} else {
 		for _, index := range indexesForEmailTemplatesCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for email templates collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/messaging/scheduledEmail.go
+++ b/pkg/db/messaging/scheduledEmail.go
@@ -1,6 +1,7 @@
 package messaging
 
 import (
+	"log/slog"
 	"time"
 
 	messagingTypes "github.com/case-framework/case-backend/pkg/messaging/types"
@@ -9,6 +10,20 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
+
+func (dbService *MessagingDBService) DropIndexForEmailSchedulesCollection(instanceID string, dropAll bool) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	if dropAll {
+		_, err := dbService.collectionEmailSchedules(instanceID).Indexes().DropAll(ctx)
+		if err != nil {
+			slog.Error("Error dropping all indexes for email schedules", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
+		}
+	} else {
+		slog.Warn("email schedules collection has no default indexes at the moment")
+	}
+}
 
 // get all scheduled emails
 func (dbService *MessagingDBService) GetAllScheduledEmails(instanceID string) ([]messagingTypes.ScheduledEmail, error) {

--- a/pkg/db/messaging/sent-emails.go
+++ b/pkg/db/messaging/sent-emails.go
@@ -1,0 +1,73 @@
+package messaging
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	messagingTypes "github.com/case-framework/case-backend/pkg/messaging/types"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var indexesForSentEmailsCollection = []mongo.IndexModel{
+	{
+		Keys: bson.D{
+			{Key: "userId", Value: 1},
+			{Key: "sentAt", Value: 1},
+		},
+		Options: options.Index().SetName("userId_sentAt_1"),
+	},
+}
+
+func (dbService *MessagingDBService) DropIndexForSentEmailsCollection(instanceID string, dropAll bool) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	if dropAll {
+		_, err := dbService.collectionSentEmails(instanceID).Indexes().DropAll(ctx)
+		if err != nil {
+			slog.Error("Error dropping all indexes for sent emails", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
+		}
+	} else {
+		for _, index := range indexesForSentEmailsCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for sent emails collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
+			indexName := *index.Options.Name
+			_, err := dbService.collectionSentEmails(instanceID).Indexes().DropOne(ctx, indexName)
+			if err != nil {
+				slog.Error("Error dropping index for sent emails", slog.String("error", err.Error()), slog.String("instanceID", instanceID), slog.String("indexName", indexName))
+			}
+		}
+	}
+}
+
+func (dbService *MessagingDBService) CreateDefaultIndexesForSentEmailsCollection(instanceID string) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	_, err := dbService.collectionSentEmails(instanceID).Indexes().CreateMany(ctx, indexesForSentEmailsCollection)
+	if err != nil {
+		slog.Error("Error creating index for sent emails", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
+	}
+}
+
+func (dbService *MessagingDBService) AddToSentEmails(instanceID string, email messagingTypes.OutgoingEmail) (messagingTypes.OutgoingEmail, error) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+	email.Content = ""
+	email.SentAt = time.Now().UTC()
+	email.To = []string{}
+
+	email.ID = primitive.NilObjectID
+	res, err := dbService.collectionSentEmails(instanceID).InsertOne(ctx, email)
+	if err != nil {
+		return email, err
+	}
+	email.ID = res.InsertedID.(primitive.ObjectID)
+	return email, nil
+}

--- a/pkg/db/messaging/sent-emails.go
+++ b/pkg/db/messaging/sent-emails.go
@@ -33,7 +33,7 @@ func (dbService *MessagingDBService) DropIndexForSentEmailsCollection(instanceID
 		}
 	} else {
 		for _, index := range indexesForSentEmailsCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for sent emails collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/messaging/sent-emails.go
+++ b/pkg/db/messaging/sent-emails.go
@@ -18,7 +18,7 @@ var indexesForSentEmailsCollection = []mongo.IndexModel{
 			{Key: "userId", Value: 1},
 			{Key: "sentAt", Value: 1},
 		},
-		Options: options.Index().SetName("userId_sentAt_1"),
+		Options: options.Index().SetName("userId_1_sentAt_1"),
 	},
 }
 

--- a/pkg/db/messaging/sent-sms.go
+++ b/pkg/db/messaging/sent-sms.go
@@ -34,7 +34,7 @@ func (dbService *MessagingDBService) DropIndexForSentSMSCollection(instanceID st
 		}
 	} else {
 		for _, index := range indexesForSentSMSCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for sent SMS collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/messaging/sent-sms.go
+++ b/pkg/db/messaging/sent-sms.go
@@ -19,7 +19,7 @@ var indexesForSentSMSCollection = []mongo.IndexModel{
 			{Key: "sentAt", Value: 1},
 			{Key: "messageType", Value: 1},
 		},
-		Options: options.Index().SetName("userID_sentAt_messageType_1"),
+		Options: options.Index().SetName("userID_1_sentAt_1_messageType_1"),
 	},
 }
 

--- a/pkg/db/messaging/sms-templates.go
+++ b/pkg/db/messaging/sms-templates.go
@@ -31,7 +31,7 @@ func (messagingDBService *MessagingDBService) DropIndexForSMSTemplatesCollection
 		}
 	} else {
 		for _, index := range indexesForSMSTemplatesCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for SMS templates collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/participant-user/db.go
+++ b/pkg/db/participant-user/db.go
@@ -2,6 +2,7 @@ package participantuser
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/case-framework/case-backend/pkg/db"
@@ -88,20 +89,26 @@ func (dbService *ParticipantUserDBService) collectionFailedOtpAttempts(instanceI
 
 func (dbService *ParticipantUserDBService) CreateDefaultIndexes() {
 	for _, instanceID := range dbService.InstanceIDs {
+		start := time.Now()
+		slog.Info("Creating default indexes for participant user DB", slog.String("instanceID", instanceID))
 		dbService.CreateDefaultIndexesForParticipantUsersCollection(instanceID)
 		dbService.CreateDefaultIndexesForParticipantUserAttributesCollection(instanceID)
 		dbService.CreateDefaultIndexesForRenewTokensCollection(instanceID)
 		dbService.CreateDefaultIndexesForOTPsCollection(instanceID)
 		dbService.CreateDefaultIndexesForFailedOtpAttemptsCollection(instanceID)
+		slog.Info("Default indexes created for participant user DB", slog.String("instanceID", instanceID), slog.String("duration", time.Since(start).String()))
 	}
 }
 
 func (dbService *ParticipantUserDBService) DropIndexes(dropAll bool) {
 	for _, instanceID := range dbService.InstanceIDs {
+		start := time.Now()
+		slog.Info("Dropping indexes for participant user DB", slog.String("instanceID", instanceID))
 		dbService.DropIndexForParticipantUsersCollection(instanceID, dropAll)
 		dbService.DropIndexForParticipantUserAttributesCollection(instanceID, dropAll)
 		dbService.DropIndexForRenewTokensCollection(instanceID, dropAll)
 		dbService.DropIndexForOTPsCollection(instanceID, dropAll)
 		dbService.DropIndexForFailedOtpAttemptsCollection(instanceID, dropAll)
+		slog.Info("Indexes dropped for participant user DB", slog.String("instanceID", instanceID), slog.String("duration", time.Since(start).String()))
 	}
 }

--- a/pkg/db/participant-user/failedOtpAttempts.go
+++ b/pkg/db/participant-user/failedOtpAttempts.go
@@ -45,7 +45,7 @@ func (dbService *ParticipantUserDBService) DropIndexForFailedOtpAttemptsCollecti
 		}
 	} else {
 		for _, index := range indexesForFailedOtpAttemptsCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for FailedOtpAttempts collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/participant-user/failedOtpAttempts.go
+++ b/pkg/db/participant-user/failedOtpAttempts.go
@@ -1,6 +1,7 @@
 package participantuser
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -18,30 +19,53 @@ type FailedOtpAttempt struct {
 	UserID    string    `json:"userId" bson:"userID"`
 }
 
-func (dbService *ParticipantUserDBService) CreateIndexForFailedOtpAttempts(instanceID string) error {
+var indexesForFailedOtpAttemptsCollection = []mongo.IndexModel{
+	{
+		Keys: bson.D{
+			{Key: "userID", Value: 1},
+		},
+		Options: options.Index().SetName("userID_1"),
+	},
+	{
+		Keys: bson.D{
+			{Key: "timestamp", Value: 1},
+		},
+		Options: options.Index().SetExpireAfterSeconds(FAILED_OTP_ATTEMP_WINDOW).SetName("timestamp_1"),
+	},
+}
+
+func (dbService *ParticipantUserDBService) DropIndexForFailedOtpAttemptsCollection(instanceID string, dropAll bool) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
-	if _, err := dbService.collectionFailedOtpAttempts(instanceID).Indexes().DropAll(ctx); err != nil {
-		slog.Error("Error dropping indexes for FailedOtpAttempts", slog.String("error", err.Error()))
+	if dropAll {
+		_, err := dbService.collectionFailedOtpAttempts(instanceID).Indexes().DropAll(ctx)
+		if err != nil {
+			slog.Error("Error dropping all indexes for FailedOtpAttempts", slog.String("error", err.Error()))
+		}
+	} else {
+		for _, index := range indexesForFailedOtpAttemptsCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for FailedOtpAttempts collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
+			indexName := *index.Options.Name
+			_, err := dbService.collectionFailedOtpAttempts(instanceID).Indexes().DropOne(ctx, indexName)
+			if err != nil {
+				slog.Error("Error dropping index for FailedOtpAttempts", slog.String("error", err.Error()), slog.String("indexName", indexName))
+			}
+		}
 	}
+}
 
-	_, err := dbService.collectionFailedOtpAttempts(instanceID).Indexes().CreateMany(
-		ctx, []mongo.IndexModel{
-			{
-				Keys: bson.D{
-					{Key: "userID", Value: 1},
-				},
-			},
-			{
-				Keys: bson.D{
-					{Key: "timestamp", Value: 1},
-				},
-				Options: options.Index().SetExpireAfterSeconds(FAILED_OTP_ATTEMP_WINDOW),
-			},
-		},
-	)
-	return err
+func (dbService *ParticipantUserDBService) CreateDefaultIndexesForFailedOtpAttemptsCollection(instanceID string) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	_, err := dbService.collectionFailedOtpAttempts(instanceID).Indexes().CreateMany(ctx, indexesForFailedOtpAttemptsCollection)
+	if err != nil {
+		slog.Error("Error creating index for FailedOtpAttempts", slog.String("error", err.Error()))
+	}
 }
 
 func (dbService *ParticipantUserDBService) CountFailedOtpAttempts(instanceID string, userID string) (int64, error) {

--- a/pkg/db/participant-user/otps.go
+++ b/pkg/db/participant-user/otps.go
@@ -23,7 +23,7 @@ var indexesForOTPsCollection = []mongo.IndexModel{
 			{Key: "userID", Value: 1},
 			{Key: "code", Value: 1},
 		},
-		Options: options.Index().SetUnique(true).SetName("userID_code_1"),
+		Options: options.Index().SetUnique(true).SetName("uniq_userID_1_code_1"),
 	},
 	{
 		Keys: bson.D{

--- a/pkg/db/participant-user/otps.go
+++ b/pkg/db/participant-user/otps.go
@@ -44,7 +44,7 @@ func (dbService *ParticipantUserDBService) DropIndexForOTPsCollection(instanceID
 		}
 	} else {
 		for _, index := range indexesForOTPsCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for OTPs collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/participant-user/renew-tokens.go
+++ b/pkg/db/participant-user/renew-tokens.go
@@ -25,14 +25,14 @@ var indexesForRenewTokensCollection = []mongo.IndexModel{
 			{Key: "renewToken", Value: 1},
 			{Key: "expiresAt", Value: 1},
 		},
-		Options: options.Index().SetName("userID_renewToken_expiresAt_1"),
+		Options: options.Index().SetName("userID_1_renewToken_1_expiresAt_1"),
 	},
 	{
 		Keys: bson.D{
 			{Key: "userID", Value: 1},
 			{Key: "sessionID", Value: 1},
 		},
-		Options: options.Index().SetName("userID_sessionID_1"),
+		Options: options.Index().SetName("userID_1_sessionID_1"),
 	},
 	{
 		Keys: bson.D{
@@ -44,7 +44,7 @@ var indexesForRenewTokensCollection = []mongo.IndexModel{
 		Keys: bson.D{
 			{Key: "renewToken", Value: 1},
 		},
-		Options: options.Index().SetUnique(true).SetName("renewToken_1"),
+		Options: options.Index().SetUnique(true).SetName("uniq_renewToken_1"),
 	},
 }
 

--- a/pkg/db/participant-user/renew-tokens.go
+++ b/pkg/db/participant-user/renew-tokens.go
@@ -59,7 +59,7 @@ func (dbService *ParticipantUserDBService) DropIndexForRenewTokensCollection(ins
 		}
 	} else {
 		for _, index := range indexesForRenewTokensCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for renew tokens collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/participant-user/renew-tokens.go
+++ b/pkg/db/participant-user/renew-tokens.go
@@ -113,7 +113,7 @@ func (dbService *ParticipantUserDBService) DeleteRenewTokenByToken(instanceID st
 		return err
 	}
 	if res.DeletedCount < 1 {
-		return errors.New("no renew token oject found with the given token value")
+		return errors.New("no renew token object found with the given token value")
 	}
 	return nil
 }

--- a/pkg/db/participant-user/user-attributes.go
+++ b/pkg/db/participant-user/user-attributes.go
@@ -28,18 +28,18 @@ func (dbService *ParticipantUserDBService) DropIndexForParticipantUserAttributes
 	if dropAll {
 		_, err := dbService.collectionParticipantUserAttributes(instanceID).Indexes().DropAll(ctx)
 		if err != nil {
-			slog.Error("Error dropping all indexes for participant user attributes", slog.String("error", err.Error()))
+			slog.Error("Error dropping all indexes for participant user attributes", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
 		}
 	} else {
 		for _, index := range indexesForParticipantUserAttributesCollection {
 			if index.Options.Name == nil {
-				slog.Error("Index name is nil for participant user attributes collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				slog.Error("Index name is nil for participant user attributes collection", slog.String("index", fmt.Sprintf("%+v", index)), slog.String("instanceID", instanceID))
 				continue
 			}
 			indexName := *index.Options.Name
 			_, err := dbService.collectionParticipantUserAttributes(instanceID).Indexes().DropOne(ctx, indexName)
 			if err != nil {
-				slog.Error("Error dropping index for participant user attributes", slog.String("error", err.Error()), slog.String("indexName", indexName))
+				slog.Error("Error dropping index for participant user attributes", slog.String("error", err.Error()), slog.String("indexName", indexName), slog.String("instanceID", instanceID))
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func (dbService *ParticipantUserDBService) CreateDefaultIndexesForParticipantUse
 
 	_, err := dbService.collectionParticipantUserAttributes(instanceID).Indexes().CreateMany(ctx, indexesForParticipantUserAttributesCollection)
 	if err != nil {
-		slog.Error("Error creating index for participant user attributes", slog.String("error", err.Error()))
+		slog.Error("Error creating index for participant user attributes", slog.String("error", err.Error()), slog.String("instanceID", instanceID))
 	}
 }
 

--- a/pkg/db/participant-user/user-attributes.go
+++ b/pkg/db/participant-user/user-attributes.go
@@ -17,7 +17,7 @@ import (
 var indexesForParticipantUserAttributesCollection = []mongo.IndexModel{
 	{
 		Keys:    bson.D{{Key: "userId", Value: 1}, {Key: "type", Value: 1}},
-		Options: options.Index().SetName("idx_user_attributes_userId").SetUnique(true),
+		Options: options.Index().SetName("userId_1_type_1").SetUnique(true),
 	},
 }
 

--- a/pkg/db/participant-user/user-attributes.go
+++ b/pkg/db/participant-user/user-attributes.go
@@ -32,7 +32,7 @@ func (dbService *ParticipantUserDBService) DropIndexForParticipantUserAttributes
 		}
 	} else {
 		for _, index := range indexesForParticipantUserAttributesCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for participant user attributes collection", slog.String("index", fmt.Sprintf("%+v", index)), slog.String("instanceID", instanceID))
 				continue
 			}

--- a/pkg/db/participant-user/user-attributes.go
+++ b/pkg/db/participant-user/user-attributes.go
@@ -2,6 +2,7 @@ package participantuser
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -13,25 +14,45 @@ import (
 	userTypes "github.com/case-framework/case-backend/pkg/user-management/types"
 )
 
-func (dbService *ParticipantUserDBService) CreateIndexForParticipantUserAttributes(instanceID string) error {
+var indexesForParticipantUserAttributesCollection = []mongo.IndexModel{
+	{
+		Keys:    bson.D{{Key: "userId", Value: 1}, {Key: "type", Value: 1}},
+		Options: options.Index().SetName("idx_user_attributes_userId").SetUnique(true),
+	},
+}
+
+func (dbService *ParticipantUserDBService) DropIndexForParticipantUserAttributesCollection(instanceID string, dropAll bool) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
-	const idxName = "idx_user_attributes_userId"
-
-	if _, err := dbService.collectionParticipantUserAttributes(instanceID).Indexes().DropOne(ctx, idxName); err != nil {
-		// Index might not exist yet; log at debug level
-		slog.Debug("Drop index for participant user attributes", slog.String("index", idxName), slog.String("error", err.Error()))
+	if dropAll {
+		_, err := dbService.collectionParticipantUserAttributes(instanceID).Indexes().DropAll(ctx)
+		if err != nil {
+			slog.Error("Error dropping all indexes for participant user attributes", slog.String("error", err.Error()))
+		}
+	} else {
+		for _, index := range indexesForParticipantUserAttributesCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for participant user attributes collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
+			indexName := *index.Options.Name
+			_, err := dbService.collectionParticipantUserAttributes(instanceID).Indexes().DropOne(ctx, indexName)
+			if err != nil {
+				slog.Error("Error dropping index for participant user attributes", slog.String("error", err.Error()), slog.String("indexName", indexName))
+			}
+		}
 	}
+}
 
-	_, err := dbService.collectionParticipantUserAttributes(instanceID).Indexes().CreateOne(
-		ctx,
-		mongo.IndexModel{
-			Keys:    bson.D{{Key: "userId", Value: 1}, {Key: "type", Value: 1}},
-			Options: options.Index().SetName(idxName).SetUnique(true),
-		},
-	)
-	return err
+func (dbService *ParticipantUserDBService) CreateDefaultIndexesForParticipantUserAttributesCollection(instanceID string) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	_, err := dbService.collectionParticipantUserAttributes(instanceID).Indexes().CreateMany(ctx, indexesForParticipantUserAttributesCollection)
+	if err != nil {
+		slog.Error("Error creating index for participant user attributes", slog.String("error", err.Error()))
+	}
 }
 
 // Create or update a user attribute for a user by type

--- a/pkg/db/participant-user/users.go
+++ b/pkg/db/participant-user/users.go
@@ -26,7 +26,8 @@ var indexesForParticipantUsersCollection = []mongo.IndexModel{
 		Keys: bson.D{
 			{Key: "account.accountID", Value: 1},
 		},
-		Options: options.Index().SetName("account.accountID_1"),
+		Options: options.Index().SetUnique(true).
+			SetName("uniq_account.accountID_1"),
 	},
 	{
 		Keys: bson.D{

--- a/pkg/db/participant-user/users.go
+++ b/pkg/db/participant-user/users.go
@@ -60,7 +60,7 @@ func (dbService *ParticipantUserDBService) DropIndexForParticipantUsersCollectio
 		}
 	} else {
 		for _, index := range indexesForParticipantUsersCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for participant users collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/participant-user/users.go
+++ b/pkg/db/participant-user/users.go
@@ -40,7 +40,7 @@ var indexesForParticipantUsersCollection = []mongo.IndexModel{
 			{Key: "account.accountConfirmedAt", Value: 1},
 			{Key: "timestamps.createdAt", Value: 1},
 		},
-		Options: options.Index().SetName("account.accountConfirmedAt_timestamps.createdAt_1"),
+		Options: options.Index().SetName("account.accountConfirmedAt_1_timestamps.createdAt_1"),
 	},
 	{
 		Keys: bson.D{

--- a/pkg/db/read-config.go
+++ b/pkg/db/read-config.go
@@ -86,14 +86,13 @@ func DBConfigFromYamlObj(yamlObj DBConfigYaml, instanceIDs []string) DBConfig {
 	DBNamePrefix := yamlObj.DBNamePrefix
 
 	return DBConfig{
-		URI:              URI,
-		Timeout:          Timeout,
-		IdleConnTimeout:  IdleConnTimeout,
-		MaxPoolSize:      MaxPoolSize,
-		NoCursorTimeout:  noCursorTimeout,
-		DBNamePrefix:     DBNamePrefix,
-		InstanceIDs:      instanceIDs,
-		RunIndexCreation: yamlObj.RunIndexCreation,
+		URI:             URI,
+		Timeout:         Timeout,
+		IdleConnTimeout: IdleConnTimeout,
+		MaxPoolSize:     MaxPoolSize,
+		NoCursorTimeout: noCursorTimeout,
+		DBNamePrefix:    DBNamePrefix,
+		InstanceIDs:     instanceIDs,
 	}
 
 }

--- a/pkg/db/study/confidential-id-map.go
+++ b/pkg/db/study/confidential-id-map.go
@@ -31,7 +31,7 @@ func (dbService *StudyDBService) DropIndexForConfidentialIDMapCollection(instanc
 		}
 	} else {
 		for _, index := range indexesForConfidentialIDMapCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for confidentialIDMap collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/confidential-id-map.go
+++ b/pkg/db/study/confidential-id-map.go
@@ -15,7 +15,7 @@ var indexesForConfidentialIDMapCollection = []mongo.IndexModel{
 			{Key: "confidentialID", Value: 1},
 			{Key: "studyKey", Value: 1},
 		},
-		Options: options.Index().SetUnique(true).SetName("confidentialID_studyKey_1"),
+		Options: options.Index().SetUnique(true).SetName("confidentialID_1_studyKey_1"),
 	},
 }
 

--- a/pkg/db/study/confidential-id-map.go
+++ b/pkg/db/study/confidential-id-map.go
@@ -1,6 +1,7 @@
 package study
 
 import (
+	"fmt"
 	"log/slog"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -30,6 +31,10 @@ func (dbService *StudyDBService) DropIndexForConfidentialIDMapCollection(instanc
 		}
 	} else {
 		for _, index := range indexesForConfidentialIDMapCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for confidentialIDMap collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := collection.Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/study/confidentialResponses.go
+++ b/pkg/db/study/confidentialResponses.go
@@ -36,7 +36,7 @@ func (dbService *StudyDBService) DropIndexForConfidentialResponsesCollection(ins
 		}
 	} else {
 		for _, index := range indexesForConfidentialResponsesCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for confidential responses collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/confidentialResponses.go
+++ b/pkg/db/study/confidentialResponses.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 
 	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
-	studytypes "github.com/case-framework/case-backend/pkg/study/types"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -61,7 +60,7 @@ func (dbService *StudyDBService) CreateDefaultIndexesForConfidentialResponsesCol
 	}
 }
 
-func (dbService *StudyDBService) AddConfidentialResponse(instanceID string, studyKey string, response studytypes.SurveyResponse) (string, error) {
+func (dbService *StudyDBService) AddConfidentialResponse(instanceID string, studyKey string, response studyTypes.SurveyResponse) (string, error) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 	if len(response.ParticipantID) < 1 {
@@ -72,7 +71,7 @@ func (dbService *StudyDBService) AddConfidentialResponse(instanceID string, stud
 	return id.Hex(), err
 }
 
-func (dbService *StudyDBService) ReplaceConfidentialResponse(instanceID string, studyKey string, response studytypes.SurveyResponse) error {
+func (dbService *StudyDBService) ReplaceConfidentialResponse(instanceID string, studyKey string, response studyTypes.SurveyResponse) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
@@ -89,7 +88,7 @@ func (dbService *StudyDBService) ReplaceConfidentialResponse(instanceID string, 
 	return err
 }
 
-func (dbService *StudyDBService) FindConfidentialResponses(instanceID string, studyKey string, participantID string, key string) (responses []studytypes.SurveyResponse, err error) {
+func (dbService *StudyDBService) FindConfidentialResponses(instanceID string, studyKey string, participantID string, key string) (responses []studyTypes.SurveyResponse, err error) {
 	ctx, cancel := dbService.getContext()
 	defer cancel()
 
@@ -112,9 +111,9 @@ func (dbService *StudyDBService) FindConfidentialResponses(instanceID string, st
 	}
 	defer cur.Close(ctx)
 
-	responses = []studytypes.SurveyResponse{}
+	responses = []studyTypes.SurveyResponse{}
 	for cur.Next(ctx) {
-		var result studytypes.SurveyResponse
+		var result studyTypes.SurveyResponse
 		err := cur.Decode(&result)
 		if err != nil {
 			return responses, err

--- a/pkg/db/study/confidentialResponses.go
+++ b/pkg/db/study/confidentialResponses.go
@@ -19,7 +19,7 @@ var indexesForConfidentialResponsesCollection = []mongo.IndexModel{
 			{Key: "participantID", Value: 1},
 			{Key: "key", Value: 1},
 		},
-		Options: options.Index().SetName("participantID_key_1"),
+		Options: options.Index().SetName("participantID_1_key_1"),
 	},
 }
 

--- a/pkg/db/study/confidentialResponses.go
+++ b/pkg/db/study/confidentialResponses.go
@@ -3,6 +3,7 @@ package study
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
@@ -36,6 +37,10 @@ func (dbService *StudyDBService) DropIndexForConfidentialResponsesCollection(ins
 		}
 	} else {
 		for _, index := range indexesForConfidentialResponsesCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for confidential responses collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := collection.Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/study/participants.go
+++ b/pkg/db/study/participants.go
@@ -95,13 +95,13 @@ func (dbService *StudyDBService) SaveParticipantState(instanceID string, studyKe
 
 	upsert := true
 	rd := options.After
-	options := options.FindOneAndReplaceOptions{
+	qOpts := options.FindOneAndReplaceOptions{
 		Upsert:         &upsert,
 		ReturnDocument: &rd,
 	}
 	elem := studyTypes.Participant{}
 	err := dbService.collectionParticipants(instanceID, studyKey).FindOneAndReplace(
-		ctx, filter, pState, &options,
+		ctx, filter, pState, &qOpts,
 	).Decode(&elem)
 	return elem, err
 }

--- a/pkg/db/study/participants.go
+++ b/pkg/db/study/participants.go
@@ -62,7 +62,7 @@ func (dbService *StudyDBService) DropIndexForParticipantsCollection(instanceID s
 		}
 	} else {
 		for _, index := range indexesForParticipantsCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for participants collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/participants.go
+++ b/pkg/db/study/participants.go
@@ -2,6 +2,7 @@ package study
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -61,6 +62,10 @@ func (dbService *StudyDBService) DropIndexForParticipantsCollection(instanceID s
 		}
 	} else {
 		for _, index := range indexesForParticipantsCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for participants collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := collection.Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/study/participants.go
+++ b/pkg/db/study/participants.go
@@ -1,6 +1,7 @@
 package study
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,7 +11,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"golang.org/x/net/context"
 
 	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
 )

--- a/pkg/db/study/participants.go
+++ b/pkg/db/study/participants.go
@@ -39,13 +39,13 @@ var indexesForParticipantsCollection = []mongo.IndexModel{
 			{Key: "messages.scheduledFor", Value: 1},
 			{Key: "studyStatus", Value: 1},
 		},
-		Options: options.Index().SetName("messages_scheduledFor_studyStatus_1"),
+		Options: options.Index().SetName("messages.scheduledFor_1_studyStatus_1"),
 	},
 	{
 		Keys: bson.D{
 			{Key: "messages.scheduledFor", Value: 1},
 		},
-		Options: options.Index().SetName("messages_scheduledFor_1"),
+		Options: options.Index().SetName("messages.scheduledFor_1"),
 	},
 }
 

--- a/pkg/db/study/reports.go
+++ b/pkg/db/study/reports.go
@@ -58,7 +58,7 @@ func (dbService *StudyDBService) DropIndexForReportsCollection(instanceID string
 		}
 	} else {
 		for _, index := range indexesForReportsCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for reports collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/reports.go
+++ b/pkg/db/study/reports.go
@@ -3,6 +3,7 @@ package study
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -57,6 +58,10 @@ func (dbService *StudyDBService) DropIndexForReportsCollection(instanceID string
 		}
 	} else {
 		for _, index := range indexesForReportsCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for reports collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := collection.Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/study/reports.go
+++ b/pkg/db/study/reports.go
@@ -41,7 +41,7 @@ var indexesForReportsCollection = []mongo.IndexModel{
 			{Key: "key", Value: 1},
 			{Key: "timestamp", Value: 1},
 		},
-		Options: options.Index().SetName("participantID_key_timestamp_1"),
+		Options: options.Index().SetName("participantID_1_key_1_timestamp_1"),
 	},
 }
 

--- a/pkg/db/study/responses.go
+++ b/pkg/db/study/responses.go
@@ -61,7 +61,7 @@ func (dbService *StudyDBService) DropIndexForResponsesCollection(instanceID stri
 		}
 	} else {
 		for _, index := range indexesForResponsesCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for responses collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/responses.go
+++ b/pkg/db/study/responses.go
@@ -3,6 +3,7 @@ package study
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -60,6 +61,10 @@ func (dbService *StudyDBService) DropIndexForResponsesCollection(instanceID stri
 		}
 	} else {
 		for _, index := range indexesForResponsesCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for responses collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := dbService.collectionResponses(instanceID, studyKey).Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/study/responses.go
+++ b/pkg/db/study/responses.go
@@ -28,7 +28,7 @@ var indexesForResponsesCollection = []mongo.IndexModel{
 			{Key: "key", Value: 1},
 			{Key: "submittedAt", Value: 1},
 		},
-		Options: options.Index().SetName("participantID_key_submittedAt_1"),
+		Options: options.Index().SetName("participantID_1_key_1_submittedAt_1"),
 	},
 	{
 		Keys: bson.D{

--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -36,7 +36,7 @@ func (dbService *StudyDBService) DropIndexForStudyCodeListsCollection(instanceID
 	} else {
 		for _, index := range indexesForStudyCodeListsCollection {
 			if index.Options == nil || index.Options.Name == nil {
-				slog.Error("Index name is nil for studyCodeLists collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				slog.Error("Index name is nil for studyCodeLists collection", slog.String("index", fmt.Sprintf("%+v", index)), slog.String("instanceID", instanceID))
 				continue
 			}
 			indexName := *index.Options.Name

--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -35,7 +35,7 @@ func (dbService *StudyDBService) DropIndexForStudyCodeListsCollection(instanceID
 		}
 	} else {
 		for _, index := range indexesForStudyCodeListsCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for studyCodeLists collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -9,7 +9,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
-	"github.com/case-framework/case-backend/pkg/study/types"
 	studytypes "github.com/case-framework/case-backend/pkg/study/types"
 )
 
@@ -181,7 +180,7 @@ func (dbService *StudyDBService) DrawStudyCode(instanceID string, studyKey strin
 		"listKey":  listKey,
 	}
 
-	var result types.StudyCodeListEntry
+	var result studytypes.StudyCodeListEntry
 	err := dbService.collectionStudyCodeLists(instanceID).FindOneAndDelete(ctx, filter).Decode(&result)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {

--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -19,7 +19,7 @@ var indexesForStudyCodeListsCollection = []mongo.IndexModel{
 			{Key: "listKey", Value: 1},
 			{Key: "code", Value: 1},
 		},
-		Options: options.Index().SetUnique(true).SetName("studyKey_listKey_code_1"),
+		Options: options.Index().SetUnique(true).SetName("studyKey_1_listKey_1_code_1"),
 	},
 }
 

--- a/pkg/db/study/study-code-lists.go
+++ b/pkg/db/study/study-code-lists.go
@@ -1,6 +1,7 @@
 package study
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -35,6 +36,10 @@ func (dbService *StudyDBService) DropIndexForStudyCodeListsCollection(instanceID
 		}
 	} else {
 		for _, index := range indexesForStudyCodeListsCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for studyCodeLists collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := collection.Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/study/study-counters.go
+++ b/pkg/db/study/study-counters.go
@@ -37,7 +37,7 @@ func (dbService *StudyDBService) DropIndexForStudyCountersCollection(instanceID 
 		}
 	} else {
 		for _, index := range indexesForStudyCountersCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for studyCounters collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/study-counters.go
+++ b/pkg/db/study/study-counters.go
@@ -21,7 +21,7 @@ var indexesForStudyCountersCollection = []mongo.IndexModel{
 			{Key: "studyKey", Value: 1},
 			{Key: "scope", Value: 1},
 		},
-		Options: options.Index().SetUnique(true).SetName("studyKey_scope_1"),
+		Options: options.Index().SetUnique(true).SetName("studyKey_1_scope_1"),
 	},
 }
 

--- a/pkg/db/study/study-counters.go
+++ b/pkg/db/study/study-counters.go
@@ -1,6 +1,7 @@
 package study
 
 import (
+	"fmt"
 	"log/slog"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -36,6 +37,10 @@ func (dbService *StudyDBService) DropIndexForStudyCountersCollection(instanceID 
 		}
 	} else {
 		for _, index := range indexesForStudyCountersCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for studyCounters collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := collection.Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/study/study-counters.go
+++ b/pkg/db/study/study-counters.go
@@ -38,7 +38,7 @@ func (dbService *StudyDBService) DropIndexForStudyCountersCollection(instanceID 
 	} else {
 		for _, index := range indexesForStudyCountersCollection {
 			if index.Options == nil || index.Options.Name == nil {
-				slog.Error("Index name is nil for studyCounters collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				slog.Error("Index name is nil for studyCounters collection", slog.String("index", fmt.Sprintf("%+v", index)), slog.String("instanceID", instanceID))
 				continue
 			}
 			indexName := *index.Options.Name

--- a/pkg/db/study/studyInfos.go
+++ b/pkg/db/study/studyInfos.go
@@ -32,7 +32,7 @@ func (dbService *StudyDBService) DropIndexForStudyInfosCollection(instanceID str
 		}
 	} else {
 		for _, index := range indexesForStudyInfosCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for studyInfos collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/studyInfos.go
+++ b/pkg/db/study/studyInfos.go
@@ -1,6 +1,7 @@
 package study
 
 import (
+	"fmt"
 	"log/slog"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -31,6 +32,10 @@ func (dbService *StudyDBService) DropIndexForStudyInfosCollection(instanceID str
 		}
 	} else {
 		for _, index := range indexesForStudyInfosCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for studyInfos collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := dbService.collectionStudyInfos(instanceID).Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/study/studyRules.go
+++ b/pkg/db/study/studyRules.go
@@ -1,6 +1,7 @@
 package study
 
 import (
+	"fmt"
 	"log/slog"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -40,6 +41,10 @@ func (dbService *StudyDBService) DropIndexForStudyRulesCollection(instanceID str
 		}
 	} else {
 		for _, index := range indexesForStudyRulesCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for studyRules collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := collection.Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/study/studyRules.go
+++ b/pkg/db/study/studyRules.go
@@ -41,7 +41,7 @@ func (dbService *StudyDBService) DropIndexForStudyRulesCollection(instanceID str
 		}
 	} else {
 		for _, index := range indexesForStudyRulesCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for studyRules collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/studyRules.go
+++ b/pkg/db/study/studyRules.go
@@ -24,7 +24,7 @@ var indexesForStudyRulesCollection = []mongo.IndexModel{
 			{Key: "uploadedAt", Value: 1},
 			{Key: "studyKey", Value: 1},
 		},
-		Options: options.Index().SetName("uploadedAt_studyKey_1"),
+		Options: options.Index().SetName("uploadedAt_1_studyKey_1"),
 	},
 }
 

--- a/pkg/db/study/surveys.go
+++ b/pkg/db/study/surveys.go
@@ -2,6 +2,7 @@ package study
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -55,6 +56,10 @@ func (dbService *StudyDBService) DropIndexForSurveysCollection(instanceID string
 		}
 	} else {
 		for _, index := range indexesForSurveysCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for surveys collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := dbService.collectionSurveys(instanceID, studyKey).Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/study/surveys.go
+++ b/pkg/db/study/surveys.go
@@ -56,7 +56,7 @@ func (dbService *StudyDBService) DropIndexForSurveysCollection(instanceID string
 		}
 	} else {
 		for _, index := range indexesForSurveysCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for surveys collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/surveys.go
+++ b/pkg/db/study/surveys.go
@@ -21,14 +21,14 @@ var indexesForSurveysCollection = []mongo.IndexModel{
 			{Key: "unpublished", Value: 1},
 			{Key: "published", Value: -1},
 		},
-		Options: options.Index().SetName("surveyDefinition.key_unpublished_published_1"),
+		Options: options.Index().SetName("surveyDefinition.key_1_unpublished_1_published_-1"),
 	},
 	{
 		Keys: bson.D{
 			{Key: "published", Value: 1},
 			{Key: "surveyDefinition.key", Value: 1},
 		},
-		Options: options.Index().SetName("published_surveyDefinition.key_1"),
+		Options: options.Index().SetName("published_1_surveyDefinition.key_1"),
 	},
 	{
 		Keys: bson.D{
@@ -41,7 +41,7 @@ var indexesForSurveysCollection = []mongo.IndexModel{
 			{Key: "surveyDefinition.key", Value: 1},
 			{Key: "versionID", Value: 1},
 		},
-		Options: options.Index().SetName("surveyDefinition.key_versionID_1").SetUnique(true),
+		Options: options.Index().SetName("surveyDefinition.key_1_versionID_1").SetUnique(true),
 	},
 }
 

--- a/pkg/db/study/taskQueue.go
+++ b/pkg/db/study/taskQueue.go
@@ -35,7 +35,7 @@ func (dbService *StudyDBService) DropIndexForTaskQueueCollection(instanceID stri
 		}
 	} else {
 		for _, index := range indexesForTaskQueueCollection {
-			if index.Options.Name == nil {
+			if index.Options == nil || index.Options.Name == nil {
 				slog.Error("Index name is nil for task queue collection", slog.String("index", fmt.Sprintf("%+v", index)))
 				continue
 			}

--- a/pkg/db/study/taskQueue.go
+++ b/pkg/db/study/taskQueue.go
@@ -1,6 +1,7 @@
 package study
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -34,6 +35,10 @@ func (dbService *StudyDBService) DropIndexForTaskQueueCollection(instanceID stri
 		}
 	} else {
 		for _, index := range indexesForTaskQueueCollection {
+			if index.Options.Name == nil {
+				slog.Error("Index name is nil for task queue collection", slog.String("index", fmt.Sprintf("%+v", index)))
+				continue
+			}
 			indexName := *index.Options.Name
 			_, err := dbService.collectionTaskQueue(instanceID).Indexes().DropOne(ctx, indexName)
 			if err != nil {

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -1,14 +1,13 @@
 package db
 
 type DBConfig struct {
-	URI              string
-	DBNamePrefix     string
-	Timeout          int
-	NoCursorTimeout  bool
-	MaxPoolSize      uint64
-	IdleConnTimeout  int
-	InstanceIDs      []string
-	RunIndexCreation bool
+	URI             string
+	DBNamePrefix    string
+	Timeout         int
+	NoCursorTimeout bool
+	MaxPoolSize     uint64
+	IdleConnTimeout int
+	InstanceIDs     []string
 }
 
 type DBConfigYaml struct {
@@ -21,5 +20,4 @@ type DBConfigYaml struct {
 	MaxPoolSize        int    `yaml:"max_pool_size"`
 	UseNoCursorTimeout bool   `yaml:"use_no_cursor_timeout"`
 	DBNamePrefix       string `yaml:"db_name_prefix"`
-	RunIndexCreation   bool   `yaml:"run_index_creation"`
 }

--- a/pkg/db/utils.go
+++ b/pkg/db/utils.go
@@ -1,0 +1,27 @@
+package db
+
+import (
+	"context"
+	"errors"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func ListCollectionIndexes(ctx context.Context, collection *mongo.Collection) ([]bson.M, error) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		var cmdErr mongo.CommandError
+		if errors.As(err, &cmdErr) && cmdErr.Code == 26 {
+			return []bson.M{}, nil
+		}
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	indexes := []bson.M{}
+	if err = cursor.All(ctx, &indexes); err != nil {
+		return nil, err
+	}
+	return indexes, nil
+}

--- a/services/management-api/README.md
+++ b/services/management-api/README.md
@@ -49,7 +49,7 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
+
   management_user_db:
     connection_str: "<connection_str>"
     username: "<env var MANAGEMENT_USER_DB_USERNAME>"
@@ -60,7 +60,7 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
+
   global_infos_db:
     connection_str: "<connection_str>"
     username: "<env var GLOBAL_INFOS_DB_USERNAME>"
@@ -71,7 +71,7 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
+
   messaging_db:
     connection_str: "<connection_str>"
     username: "<env var MESSAGING_DB_USERNAME>"
@@ -82,7 +82,7 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
+
   study_db:
     connection_str: "<connection_str>"
     username: "<env var STUDY_DB_USERNAME>"
@@ -93,7 +93,6 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
 study_configs:
   global_secret: "your-study-global-secret"

--- a/services/participant-api/README.md
+++ b/services/participant-api/README.md
@@ -65,7 +65,7 @@ logging:
   max_age: 28
   max_backups: 3
   compress_old_logs: true
-  include_build_info: true
+  include_build_info: "once" # one of: never, always, once
 
 # Gin web server configuration
 gin_config:

--- a/services/participant-api/README.md
+++ b/services/participant-api/README.md
@@ -146,7 +146,6 @@ db_configs:
     max_pool_size: 8
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
   participant_user_db:
     connection_str: "<connection_str>"
@@ -158,7 +157,6 @@ db_configs:
     max_pool_size: 8
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
   global_infos_db:
     connection_str: "<connection_str>"
@@ -170,7 +168,6 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
   messaging_db:
     connection_str: "<connection_str>"
@@ -182,7 +179,6 @@ db_configs:
     max_pool_size: 4
     use_no_cursor_timeout: false
     db_name_prefix: ""
-    run_index_creation: false
 
 # Study module configuration
 study_configs:


### PR DESCRIPTION
## Breaking change:

DB index creation was removed from the services and jobs and included in a separate job `db-migration`. 
The `run_index_creation` boolean value on the DB configs (yaml file) is not accepted any more. Remove this from your config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone DB migration CLI/job with README, env-based config overrides, index export/import, and migration task support.

* **Refactor**
  * Removed automatic index creation at startup; index management moved to explicit per-service create/drop/get APIs with improved logging, timing, and per-instance handling.

* **Documentation**
  * Updated job/service READMEs: removed run_index_creation examples and changed logging.include_build_info examples to "once".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->