### PR TITLE
fix: initialize ExtraCtxCols in ParseResponseExportQueryFromCtx function

### DIFF
--- a/pkg/apihelpers/parsePaginatedQuery.go
+++ b/pkg/apihelpers/parsePaginatedQuery.go
@@ -123,6 +123,7 @@ func ParseResponseExportQueryFromCtx(c *gin.Context) (*ResponseExportQuery, erro
 
 	extraCtxColsQuery := c.DefaultQuery("extraContextColumns", "")
 	if extraCtxColsQuery != "" {
+		q.ExtraCtxCols = &[]string{}
 		*q.ExtraCtxCols = strings.Split(extraCtxColsQuery, ",")
 	}
 

--- a/pkg/apihelpers/parsePaginatedQuery.go
+++ b/pkg/apihelpers/parsePaginatedQuery.go
@@ -123,8 +123,8 @@ func ParseResponseExportQueryFromCtx(c *gin.Context) (*ResponseExportQuery, erro
 
 	extraCtxColsQuery := c.DefaultQuery("extraContextColumns", "")
 	if extraCtxColsQuery != "" {
-		q.ExtraCtxCols = &[]string{}
-		*q.ExtraCtxCols = strings.Split(extraCtxColsQuery, ",")
+		splitResult := strings.Split(extraCtxColsQuery, ",")
+		q.ExtraCtxCols = &splitResult
 	}
 
 	// TODO


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Properly sets `q.ExtraCtxCols` to the address of the split results to prevent nil-pointer usage when `extraContextColumns` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6189ee5ded2160568f4ac6148f33209bb9597f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rare crash when handling paginated queries that include additional context columns, improving stability.
  * Ensures additional context columns are populated safely to avoid unexpected errors.
  * Behavior, parameters, and results remain unchanged; reliability is improved for impacted flows.
  * No configuration or migration required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->