### PR TITLE
Update report api

### DIFF
--- a/pkg/db/study/reports.go
+++ b/pkg/db/study/reports.go
@@ -120,8 +120,14 @@ func (dbService *StudyDBService) UpdateReportData(instanceID string, studyKey st
 
 	filter := bson.M{"_id": _id, "participantID": participantID}
 	update := bson.M{"$set": bson.M{"data": data, "modifiedAt": time.Now()}}
-	_, err = dbService.collectionReports(instanceID, studyKey).UpdateOne(ctx, filter, update)
-	return err
+	res, err := dbService.collectionReports(instanceID, studyKey).UpdateOne(ctx, filter, update)
+	if err != nil {
+		return err
+	}
+	if res.ModifiedCount == 0 {
+		return errors.New("report not found, does not belong to participant or could not be updated")
+	}
+	return nil
 }
 
 var reportSortOnTimestamp = bson.D{

--- a/pkg/db/study/reports.go
+++ b/pkg/db/study/reports.go
@@ -140,7 +140,10 @@ func (dbService *StudyDBService) UpdateReportData(
 		update["$set"] = bson.M{"modifiedAt": time.Now()}
 	case UpdateParticipantReportModeReplace:
 		update["$set"] = bson.M{"data": data, "modifiedAt": time.Now()}
+	default:
+		return fmt.Errorf("invalid mode: %s", mode)
 	}
+
 	res, err := dbService.collectionReports(instanceID, studyKey).UpdateOne(ctx, filter, update)
 	if err != nil {
 		return err

--- a/pkg/db/study/reports.go
+++ b/pkg/db/study/reports.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -105,6 +106,22 @@ func (dbService *StudyDBService) GetReportByID(instanceID string, studyKey strin
 
 	err = dbService.collectionReports(instanceID, studyKey).FindOne(ctx, filter).Decode(&report)
 	return report, err
+}
+
+// update report data
+func (dbService *StudyDBService) UpdateReportData(instanceID string, studyKey string, reportID string, participantID string, data []studyTypes.ReportData) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	_id, err := primitive.ObjectIDFromHex(reportID)
+	if err != nil {
+		return err
+	}
+
+	filter := bson.M{"_id": _id, "participantID": participantID}
+	update := bson.M{"$set": bson.M{"data": data, "modifiedAt": time.Now()}}
+	_, err = dbService.collectionReports(instanceID, studyKey).UpdateOne(ctx, filter, update)
+	return err
 }
 
 var reportSortOnTimestamp = bson.D{

--- a/pkg/permission-checker/constants.go
+++ b/pkg/permission-checker/constants.go
@@ -49,6 +49,7 @@ const (
 	ACTION_GET_PARTICIPANT_STATES     = "get-participant-states"
 	ACTION_MERGE_PARTICIPANTS         = "merge-participants"
 	ACTION_GET_REPORTS                = "get-reports"
+	ACTION_UPDATE_REPORTS             = "update-reports"
 	ACTION_DELETE_REPORTS             = "delete-reports"
 
 	ACTION_DELETE_USERS = "delete-users"

--- a/pkg/permission-checker/constants.go
+++ b/pkg/permission-checker/constants.go
@@ -49,7 +49,6 @@ const (
 	ACTION_GET_PARTICIPANT_STATES     = "get-participant-states"
 	ACTION_MERGE_PARTICIPANTS         = "merge-participants"
 	ACTION_GET_REPORTS                = "get-reports"
-	ACTION_UPDATE_REPORTS             = "update-reports"
 	ACTION_DELETE_REPORTS             = "delete-reports"
 
 	ACTION_DELETE_USERS = "delete-users"

--- a/pkg/study/types/report.go
+++ b/pkg/study/types/report.go
@@ -1,6 +1,10 @@
 package types
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
 type Report struct {
 	ID            primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
@@ -8,6 +12,7 @@ type Report struct {
 	ParticipantID string             `bson:"participantID" json:"participantID"` // reference to the study specific participant ID
 	ResponseID    string             `bson:"responseID" json:"responseID"`       // reference to the report
 	Timestamp     int64              `bson:"timestamp" json:"timestamp"`
+	ModifiedAt    time.Time          `bson:"modifiedAt" json:"modifiedAt"` // if report is updated later, this is the time of the update
 	Data          []ReportData       `bson:"data" json:"data,omitempty"`
 }
 

--- a/pkg/study/types/report.go
+++ b/pkg/study/types/report.go
@@ -12,7 +12,7 @@ type Report struct {
 	ParticipantID string             `bson:"participantID" json:"participantID"` // reference to the study specific participant ID
 	ResponseID    string             `bson:"responseID" json:"responseID"`       // reference to the report
 	Timestamp     int64              `bson:"timestamp" json:"timestamp"`
-	ModifiedAt    time.Time          `bson:"modifiedAt" json:"modifiedAt"` // if report is updated later, this is the time of the update
+	ModifiedAt    time.Time          `bson:"modifiedAt,omitempty" json:"modifiedAt,omitempty"` // if report is updated later, this is the time of the update
 	Data          []ReportData       `bson:"data" json:"data,omitempty"`
 }
 

--- a/services/management-api/apihandlers/participant-management.go
+++ b/services/management-api/apihandlers/participant-management.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/case-framework/case-backend/pkg/apihelpers"
+	mw "github.com/case-framework/case-backend/pkg/apihelpers/middlewares"
 	jwthandling "github.com/case-framework/case-backend/pkg/jwt-handling"
 	pc "github.com/case-framework/case-backend/pkg/permission-checker"
 	studyService "github.com/case-framework/case-backend/pkg/study"
@@ -16,27 +17,31 @@ import (
 func (h *HttpEndpoints) addParticipantManagementEndpoints(rg *gin.RouterGroup) {
 	participantGroup := rg.Group("/participants")
 
-	participantGroup.POST("/virtual", h.useAuthorisedHandler(
-		RequiredPermission{
-			ResourceType:        pc.RESOURCE_TYPE_STUDY,
-			ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
-			ExtractResourceKeys: getStudyKeyFromParams,
-			Action:              pc.ACTION_CREATE_VIRTUAL_PARTICIPANT,
-		},
-		nil,
-		h.createVirtualParticipant,
-	))
+	participantGroup.POST("/virtual",
+		mw.RequirePayload(),
+		h.useAuthorisedHandler(
+			RequiredPermission{
+				ResourceType:        pc.RESOURCE_TYPE_STUDY,
+				ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
+				ExtractResourceKeys: getStudyKeyFromParams,
+				Action:              pc.ACTION_CREATE_VIRTUAL_PARTICIPANT,
+			},
+			nil,
+			h.createVirtualParticipant,
+		))
 
-	participantGroup.POST("/:participantID/responses", h.useAuthorisedHandler(
-		RequiredPermission{
-			ResourceType:        pc.RESOURCE_TYPE_STUDY,
-			ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
-			ExtractResourceKeys: getStudyKeyFromParams,
-			Action:              pc.ACTION_EDIT_PARTICIPANT_DATA,
-		},
-		nil,
-		h.submitParticipantResponse,
-	))
+	participantGroup.POST("/:participantID/responses",
+		mw.RequirePayload(),
+		h.useAuthorisedHandler(
+			RequiredPermission{
+				ResourceType:        pc.RESOURCE_TYPE_STUDY,
+				ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
+				ExtractResourceKeys: getStudyKeyFromParams,
+				Action:              pc.ACTION_EDIT_PARTICIPANT_DATA,
+			},
+			nil,
+			h.submitParticipantResponse,
+		))
 
 	participantGroup.GET("/:participantID/responses", h.useAuthorisedHandler(
 		RequiredPermission{
@@ -49,49 +54,69 @@ func (h *HttpEndpoints) addParticipantManagementEndpoints(rg *gin.RouterGroup) {
 		h.getParticipantResponses,
 	))
 
-	participantGroup.POST("/:participantID/events", h.useAuthorisedHandler(
-		RequiredPermission{
-			ResourceType:        pc.RESOURCE_TYPE_STUDY,
-			ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
-			ExtractResourceKeys: getStudyKeyFromParams,
-			Action:              pc.ACTION_EDIT_PARTICIPANT_DATA,
-		},
-		nil,
-		h.submitParticipantEvent,
-	))
+	participantGroup.POST("/:participantID/events",
+		mw.RequirePayload(),
+		h.useAuthorisedHandler(
+			RequiredPermission{
+				ResourceType:        pc.RESOURCE_TYPE_STUDY,
+				ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
+				ExtractResourceKeys: getStudyKeyFromParams,
+				Action:              pc.ACTION_EDIT_PARTICIPANT_DATA,
+			},
+			nil,
+			h.submitParticipantEvent,
+		))
 
-	participantGroup.POST("/:participantID/reports", h.useAuthorisedHandler(
-		RequiredPermission{
-			ResourceType:        pc.RESOURCE_TYPE_STUDY,
-			ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
-			ExtractResourceKeys: getStudyKeyFromParams,
-			Action:              pc.ACTION_EDIT_PARTICIPANT_DATA,
-		},
-		nil,
-		h.submitParticipantReport,
-	))
+	participantGroup.POST("/:participantID/reports",
+		mw.RequirePayload(),
+		h.useAuthorisedHandler(
+			RequiredPermission{
+				ResourceType:        pc.RESOURCE_TYPE_STUDY,
+				ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
+				ExtractResourceKeys: getStudyKeyFromParams,
+				Action:              pc.ACTION_EDIT_PARTICIPANT_DATA,
+			},
+			nil,
+			h.submitParticipantReport,
+		))
 
-	participantGroup.POST("/merge", h.useAuthorisedHandler(
-		RequiredPermission{
-			ResourceType:        pc.RESOURCE_TYPE_STUDY,
-			ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
-			ExtractResourceKeys: getStudyKeyFromParams,
-			Action:              pc.ACTION_MERGE_PARTICIPANTS,
-		},
-		nil,
-		h.mergeParticipants,
-	))
+	participantGroup.PUT("/:participantID/reports/:reportID", mw.RequirePayload(),
+		h.useAuthorisedHandler(
+			RequiredPermission{
+				ResourceType:        pc.RESOURCE_TYPE_STUDY,
+				ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
+				ExtractResourceKeys: getStudyKeyFromParams,
+				Action:              pc.ACTION_EDIT_PARTICIPANT_DATA,
+			},
+			nil,
+			h.updateParticipantReport,
+		))
 
-	participantGroup.PUT("/:participantID", h.useAuthorisedHandler(
-		RequiredPermission{
-			ResourceType:        pc.RESOURCE_TYPE_STUDY,
-			ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
-			ExtractResourceKeys: getStudyKeyFromParams,
-			Action:              pc.ACTION_EDIT_PARTICIPANT_DATA,
-		},
-		nil,
-		h.editStudyParticipant,
-	))
+	participantGroup.POST("/merge",
+		mw.RequirePayload(),
+		h.useAuthorisedHandler(
+			RequiredPermission{
+				ResourceType:        pc.RESOURCE_TYPE_STUDY,
+				ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
+				ExtractResourceKeys: getStudyKeyFromParams,
+				Action:              pc.ACTION_MERGE_PARTICIPANTS,
+			},
+			nil,
+			h.mergeParticipants,
+		))
+
+	participantGroup.PUT("/:participantID",
+		mw.RequirePayload(),
+		h.useAuthorisedHandler(
+			RequiredPermission{
+				ResourceType:        pc.RESOURCE_TYPE_STUDY,
+				ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
+				ExtractResourceKeys: getStudyKeyFromParams,
+				Action:              pc.ACTION_EDIT_PARTICIPANT_DATA,
+			},
+			nil,
+			h.editStudyParticipant,
+		))
 }
 
 func (h *HttpEndpoints) createVirtualParticipant(c *gin.Context) {
@@ -232,6 +257,36 @@ func (h *HttpEndpoints) submitParticipantReport(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "report submitted"})
+}
+
+type UpdateParticipantReportRequest struct {
+	Data []studyTypes.ReportData `json:"data"`
+}
+
+func (h *HttpEndpoints) updateParticipantReport(c *gin.Context) {
+	token := c.MustGet("validatedToken").(*jwthandling.ManagementUserClaims)
+
+	studyKey := c.Param("studyKey")
+	participantID := c.Param("participantID")
+	reportID := c.Param("reportID")
+
+	var req UpdateParticipantReportRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		slog.Error("failed to bind request", slog.String("error", err.Error()))
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	slog.Info("updating report for participant", slog.String("participantID", participantID), slog.String("studyKey", studyKey), slog.String("userID", token.Subject), slog.String("instanceID", token.InstanceID), slog.String("reportID", reportID))
+
+	err := h.studyDBConn.UpdateReportData(token.InstanceID, studyKey, reportID, participantID, req.Data)
+	if err != nil {
+		slog.Error("failed to update report", slog.String("error", err.Error()))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update report"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "report updated"})
 }
 
 type MergeParticipantsRequest struct {

--- a/services/management-api/apihandlers/participant-management.go
+++ b/services/management-api/apihandlers/participant-management.go
@@ -18,7 +18,6 @@ func (h *HttpEndpoints) addParticipantManagementEndpoints(rg *gin.RouterGroup) {
 	participantGroup := rg.Group("/participants")
 
 	participantGroup.POST("/virtual",
-		mw.RequirePayload(),
 		h.useAuthorisedHandler(
 			RequiredPermission{
 				ResourceType:        pc.RESOURCE_TYPE_STUDY,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add PUT endpoint to update participant reports (append/replace), record modifiedAt on reports, and enforce request payloads on several participant endpoints.
> 
> - **API**:
>   - **New Endpoint**: `PUT /participants/:participantID/reports/:reportID` to update report data with `mode` (`append` default, or `replace`) and `data` payload.
>   - **Payload Enforcement**: Apply `RequirePayload` middleware to `POST /:participantID/responses`, `POST /:participantID/events`, `POST /:participantID/reports`, `POST /merge`, and `PUT /:participantID`.
> - **DB/Models**:
>   - Add `UpdateReportData` in `pkg/db/study/reports.go` supporting append/replace and setting `modifiedAt`.
>   - Extend `types.Report` with `ModifiedAt` timestamp.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b98cff90b06a14d43df80838fded67d4f5044a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added endpoint to update a participant’s report: PUT /:participantID/reports/:reportID.
  - Report updates support two modes: append new items or replace the entire data set.

- **API Changes**
  - Report updates require a JSON payload with data (and optional mode); several participant endpoints now reject empty request bodies before auth.
  - Reports include a modifiedAt timestamp reflecting last update.

- **Chores**
  - Improved logging and error handling around report updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->