### PR TITLE
Enhance participant tracking with accountID and mainProfile attributes

### DIFF
--- a/jobs/user-management/init.go
+++ b/jobs/user-management/init.go
@@ -74,6 +74,7 @@ type config struct {
 		SendReminderToConfirmAccounts bool `json:"send_reminder_to_confirm_accounts" yaml:"send_reminder_to_confirm_accounts"`
 		HandleInactiveUsers           bool `json:"handle_inactive_users" yaml:"handle_inactive_users"`
 		GenerateProfileIDLookup       bool `json:"generate_profile_id_lookup" yaml:"generate_profile_id_lookup"`
+		MigrateAccountInfo            bool `json:"migrate_account_info" yaml:"migrate_account_info"`
 	} `json:"run_tasks" yaml:"run_tasks"`
 }
 
@@ -141,7 +142,7 @@ func init() {
 }
 
 func shouldInitStudyService() bool {
-	return conf.RunTasks.GenerateProfileIDLookup || conf.RunTasks.HandleInactiveUsers || conf.RunTasks.SendReminderToConfirmAccounts
+	return conf.RunTasks.GenerateProfileIDLookup || conf.RunTasks.HandleInactiveUsers || conf.RunTasks.SendReminderToConfirmAccounts || conf.RunTasks.MigrateAccountInfo
 }
 
 func secretsOverride() {

--- a/jobs/user-management/main.go
+++ b/jobs/user-management/main.go
@@ -34,6 +34,10 @@ func main() {
 		generateProfileIDLookup()
 	}
 
+	if conf.RunTasks.MigrateAccountInfo {
+		migrateAccountInfo()
+	}
+
 	slog.Info("User management jobs completed", slog.String("duration", time.Since(start).String()))
 }
 

--- a/jobs/user-management/migrate-account-info.go
+++ b/jobs/user-management/migrate-account-info.go
@@ -66,7 +66,7 @@ func migrateAccountInfo() {
 							continue
 						}
 
-						if pState.AccountInfo != nil {
+						if pState.HashedAccountID != nil {
 							// Already migrated, skip
 							continue
 						}
@@ -82,10 +82,8 @@ func migrateAccountInfo() {
 							continue
 						}
 
-						pState.AccountInfo = &studyTypes.AccountInfo{
-							HashedAccountID: hashedAccountID,
-							IsMainProfile:   isMainProfile,
-						}
+						pState.HashedAccountID = &hashedAccountID
+						pState.IsMainProfile = &isMainProfile
 
 						_, err = studyDBService.SaveParticipantState(instanceID, study.Key, pState)
 						if err != nil {

--- a/jobs/user-management/migrate-account-info.go
+++ b/jobs/user-management/migrate-account-info.go
@@ -37,6 +37,8 @@ func migrateAccountInfo() {
 
 		slog.Info("Found studies with account tracking", slog.String("instanceID", instanceID), slog.Int("count", len(trackingStudies)))
 
+		migratedCount := 0
+
 		err = participantUserDBService.FindAndExecuteOnUsers(
 			context.Background(),
 			instanceID,
@@ -87,6 +89,7 @@ func migrateAccountInfo() {
 							continue
 						}
 
+						migratedCount++
 						slog.Debug("Migrated account info for participant", slog.String("instanceID", instanceID), slog.String("studyKey", study.Key), slog.String("participantID", participantID))
 					}
 				}
@@ -97,6 +100,6 @@ func migrateAccountInfo() {
 			slog.Error("Error iterating users for account info migration", slog.String("instanceID", instanceID), slog.String("error", err.Error()))
 		}
 
-		slog.Info("Finished migrating account info for participants", slog.String("instanceID", instanceID))
+		slog.Info("Finished migrating account info for participants", slog.String("instanceID", instanceID), slog.Int("migratedCount", migratedCount))
 	}
 }

--- a/jobs/user-management/migrate-account-info.go
+++ b/jobs/user-management/migrate-account-info.go
@@ -47,6 +47,10 @@ func migrateAccountInfo() {
 			false,
 			func(user umTypes.User, args ...interface{}) error {
 				accountID := user.Account.AccountID
+				if accountID == "" {
+					return nil
+				}
+
 				mainProfileID, _ := umUtils.GetMainAndOtherProfiles(user)
 
 				for _, profile := range user.Profiles {
@@ -68,10 +72,6 @@ func migrateAccountInfo() {
 
 						if pState.HashedAccountID != nil {
 							// Already migrated, skip
-							continue
-						}
-
-						if accountID == "" {
 							continue
 						}
 

--- a/jobs/user-management/migrate-account-info.go
+++ b/jobs/user-management/migrate-account-info.go
@@ -71,6 +71,10 @@ func migrateAccountInfo() {
 							continue
 						}
 
+						if accountID == "" {
+							continue
+						}
+
 						// Reuse same hashing mechanism to pseudonymize the account ID
 						hashedAccountID, err := studyUtils.ProfileIDtoParticipantID(accountID, conf.StudyConfigs.GlobalSecret, study.SecretKey, study.Configs.IdMappingMethod)
 						if err != nil {

--- a/jobs/user-management/migrate-account-info.go
+++ b/jobs/user-management/migrate-account-info.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	studyService "github.com/case-framework/case-backend/pkg/study"
+	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
+	studyUtils "github.com/case-framework/case-backend/pkg/study/utils"
+	umTypes "github.com/case-framework/case-backend/pkg/user-management/types"
+	umUtils "github.com/case-framework/case-backend/pkg/user-management/utils"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func migrateAccountInfo() {
+	for _, instanceID := range conf.InstanceIDs {
+		slog.Info("Start migrating account info for participants", slog.String("instanceID", instanceID))
+
+		studies, err := studyDBService.GetStudies(instanceID, studyTypes.STUDY_STATUS_ACTIVE, false)
+		if err != nil {
+			slog.Error("Failed to get studies", slog.String("instanceID", instanceID), slog.String("error", err.Error()))
+			continue
+		}
+
+		// Only process studies that have account tracking enabled
+		trackingStudies := []studyTypes.Study{}
+		for _, s := range studies {
+			if s.Configs.TrackAccount {
+				trackingStudies = append(trackingStudies, s)
+			}
+		}
+
+		if len(trackingStudies) == 0 {
+			slog.Info("No studies with account tracking enabled", slog.String("instanceID", instanceID))
+			continue
+		}
+
+		slog.Info("Found studies with account tracking", slog.String("instanceID", instanceID), slog.Int("count", len(trackingStudies)))
+
+		err = participantUserDBService.FindAndExecuteOnUsers(
+			context.Background(),
+			instanceID,
+			bson.M{},
+			nil,
+			false,
+			func(user umTypes.User, args ...interface{}) error {
+				accountID := user.Account.AccountID
+				mainProfileID, _ := umUtils.GetMainAndOtherProfiles(user)
+
+				for _, profile := range user.Profiles {
+					profileID := profile.ID.Hex()
+					isMainProfile := mainProfileID == profileID
+
+					for _, study := range trackingStudies {
+						participantID, _, err := studyService.ComputeParticipantIDs(study, profileID)
+						if err != nil {
+							slog.Error("Error computing participant IDs", slog.String("instanceID", instanceID), slog.String("studyKey", study.Key), slog.String("profileID", profileID), slog.String("error", err.Error()))
+							continue
+						}
+
+						pState, err := studyDBService.GetParticipantByID(instanceID, study.Key, participantID)
+						if err != nil {
+							// Participant not in this study, skip
+							continue
+						}
+
+						if pState.AccountInfo != nil {
+							// Already migrated, skip
+							continue
+						}
+
+						// Reuse same hashing mechanism to pseudonymize the account ID
+						hashedAccountID, err := studyUtils.ProfileIDtoParticipantID(accountID, conf.StudyConfigs.GlobalSecret, study.SecretKey, study.Configs.IdMappingMethod)
+						if err != nil {
+							slog.Error("Error hashing account ID", slog.String("instanceID", instanceID), slog.String("studyKey", study.Key), slog.String("participantID", participantID), slog.String("error", err.Error()))
+							continue
+						}
+
+						pState.AccountInfo = &studyTypes.AccountInfo{
+							HashedAccountID: hashedAccountID,
+							IsMainProfile:   isMainProfile,
+						}
+
+						_, err = studyDBService.SaveParticipantState(instanceID, study.Key, pState)
+						if err != nil {
+							slog.Error("Error saving participant state", slog.String("instanceID", instanceID), slog.String("studyKey", study.Key), slog.String("participantID", participantID), slog.String("error", err.Error()))
+							continue
+						}
+
+						slog.Debug("Migrated account info for participant", slog.String("instanceID", instanceID), slog.String("studyKey", study.Key), slog.String("participantID", participantID))
+					}
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			slog.Error("Error iterating users for account info migration", slog.String("instanceID", instanceID), slog.String("error", err.Error()))
+		}
+
+		slog.Info("Finished migrating account info for participants", slog.String("instanceID", instanceID))
+	}
+}

--- a/pkg/db/study/studyInfos.go
+++ b/pkg/db/study/studyInfos.go
@@ -182,6 +182,22 @@ func (dbService *StudyDBService) UpdateStudyFileUploadRule(instanceID string, st
 	return nil
 }
 
+func (dbService *StudyDBService) UpdateStudyTrackAccount(instanceID string, studyKey string, trackAccount bool) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	collection := dbService.collectionStudyInfos(instanceID)
+	filter := bson.M{"key": studyKey}
+	update := bson.M{"$set": bson.M{"configs.trackAccount": trackAccount}}
+
+	_, err := collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (dbService *StudyDBService) UpdateStudyDisplayProps(instanceID string, studyKey string, name []studyTypes.LocalisedObject, description []studyTypes.LocalisedObject, tags []studyTypes.Tag) error {
 	ctx, cancel := dbService.getContext()
 	defer cancel()

--- a/pkg/study/study-service.go
+++ b/pkg/study/study-service.go
@@ -42,7 +42,7 @@ func Init(
 	studyengine.CurrentStudyEngine.RegisterStudyMessageSender(studyMessageSender)
 }
 
-func OnEnterStudy(instanceID string, studyKey string, profileID string) (result []studyTypes.AssignedSurvey, err error) {
+func OnEnterStudy(instanceID string, studyKey string, profileID string, accountID string, isMainProfile bool) (result []studyTypes.AssignedSurvey, err error) {
 	study, err := getStudyIfActive(instanceID, studyKey)
 	if err != nil {
 		slog.Error("error getting study", slog.String("error", err.Error()))
@@ -86,6 +86,18 @@ func OnEnterStudy(instanceID string, studyKey string, profileID string) (result 
 		// save particicpant id profile lookup
 		if err = studyDBService.AddConfidentialIDMapEntry(instanceID, confidentialID, profileID, studyKey); err != nil {
 			slog.Error("Error saving participant ID profile lookup", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("error", err.Error()))
+		}
+		if study.Configs.TrackAccount && accountID != "" {
+			// reuse same hashing mechanism to pseudonymize the account ID
+			hashedAccountID, hashErr := studyUtils.ProfileIDtoParticipantID(accountID, globalSecret, study.SecretKey, study.Configs.IdMappingMethod)
+			if hashErr != nil {
+				slog.Error("Error hashing account ID", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("error", hashErr.Error()))
+			} else {
+				pState.AccountInfo = &studyTypes.AccountInfo{
+					HashedAccountID: hashedAccountID,
+					IsMainProfile:   isMainProfile,
+				}
+			}
 		}
 	}
 

--- a/pkg/study/study-service.go
+++ b/pkg/study/study-service.go
@@ -93,10 +93,8 @@ func OnEnterStudy(instanceID string, studyKey string, profileID string, accountI
 			if hashErr != nil {
 				slog.Error("Error hashing account ID", slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("error", hashErr.Error()))
 			} else {
-				pState.AccountInfo = &studyTypes.AccountInfo{
-					HashedAccountID: hashedAccountID,
-					IsMainProfile:   isMainProfile,
-				}
+				pState.HashedAccountID = &hashedAccountID
+				pState.IsMainProfile = &isMainProfile
 			}
 		}
 	}

--- a/pkg/study/types/participant.go
+++ b/pkg/study/types/participant.go
@@ -23,6 +23,12 @@ type Participant struct {
 	AssignedSurveys     []AssignedSurvey     `bson:"assignedSurveys" json:"assignedSurveys"`
 	LastSubmissions     map[string]int64     `bson:"lastSubmission" json:"lastSubmissions"` // surveyKey with timestamp
 	Messages            []ParticipantMessage `bson:"messages" json:"messages"`
+	AccountInfo         *AccountInfo         `bson:"accountInfo,omitempty" json:"accountInfo,omitempty"`
+}
+
+type AccountInfo struct {
+	HashedAccountID string `bson:"hashedAccountID" json:"hashedAccountID"`
+	IsMainProfile   bool   `bson:"isMainProfile" json:"isMainProfile"`
 }
 
 type ParticipantMessage struct {

--- a/pkg/study/types/participant.go
+++ b/pkg/study/types/participant.go
@@ -23,12 +23,8 @@ type Participant struct {
 	AssignedSurveys     []AssignedSurvey     `bson:"assignedSurveys" json:"assignedSurveys"`
 	LastSubmissions     map[string]int64     `bson:"lastSubmission" json:"lastSubmissions"` // surveyKey with timestamp
 	Messages            []ParticipantMessage `bson:"messages" json:"messages"`
-	AccountInfo         *AccountInfo         `bson:"accountInfo,omitempty" json:"accountInfo,omitempty"`
-}
-
-type AccountInfo struct {
-	HashedAccountID string `bson:"hashedAccountID" json:"hashedAccountID"`
-	IsMainProfile   bool   `bson:"isMainProfile" json:"isMainProfile"`
+	HashedAccountID     *string              `bson:"hashedAccountID,omitempty" json:"hashedAccountID,omitempty"`
+	IsMainProfile       *bool                `bson:"isMainProfile,omitempty" json:"isMainProfile,omitempty"`
 }
 
 type ParticipantMessage struct {

--- a/pkg/study/types/study.go
+++ b/pkg/study/types/study.go
@@ -8,7 +8,7 @@ const (
 )
 
 const (
-	DEFAULT_ID_MAPPING_METHOD = "sha-256"
+	DEFAULT_ID_MAPPING_METHOD = "sha256"
 )
 
 type Study struct {

--- a/pkg/study/types/study.go
+++ b/pkg/study/types/study.go
@@ -38,6 +38,7 @@ type StudyProps struct {
 type StudyConfigs struct {
 	ParticipantFileUploadRule *Expression `bson:"participantFileUploadRule" json:"participantFileUploadRule"`
 	IdMappingMethod           string      `bson:"idMappingMethod" json:"idMappingMethod"`
+	TrackAccount              bool        `bson:"trackAccount" json:"trackAccount"`
 }
 
 type StudyStats struct {

--- a/pkg/user-management/utils/profiles.go
+++ b/pkg/user-management/utils/profiles.go
@@ -16,6 +16,9 @@ func GetMainAndOtherProfiles(user userTypes.User) (mainProfileID string, otherPr
 		}
 	}
 	if mainProfileID == "" {
+		if len(otherProfileIDs) == 0 {
+			return "", []string{}
+		}
 		mainProfileID = otherProfileIDs[0]
 		otherProfileIDs = otherProfileIDs[1:]
 	}

--- a/services/management-api/apihandlers/study-management.go
+++ b/services/management-api/apihandlers/study-management.go
@@ -163,6 +163,17 @@ func (h *HttpEndpoints) addGeneralStudyEndpoints(rg *gin.RouterGroup) {
 		h.updateStudyFileUploadRule,
 	))
 
+	rg.PUT("/track-account", mw.RequirePayload(), h.useAuthorisedHandler(
+		RequiredPermission{
+			ResourceType:        pc.RESOURCE_TYPE_STUDY,
+			ResourceKeys:        []string{pc.RESOURCE_KEY_STUDY_ALL},
+			ExtractResourceKeys: getStudyKeyFromParams,
+			Action:              pc.ACTION_UPDATE_STUDY_PROPS,
+		},
+		nil,
+		h.updateStudyTrackAccount,
+	))
+
 	rg.DELETE("/", h.useAuthorisedHandler(
 		RequiredPermission{
 			ResourceType:        pc.RESOURCE_TYPE_STUDY,
@@ -1403,6 +1414,33 @@ func (h *HttpEndpoints) updateStudyFileUploadRule(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "study file upload rule updated"})
+}
+
+type StudyTrackAccountUpdateReq struct {
+	TrackAccount bool `json:"trackAccount"`
+}
+
+func (h *HttpEndpoints) updateStudyTrackAccount(c *gin.Context) {
+	token := c.MustGet("validatedToken").(*jwthandling.ManagementUserClaims)
+
+	studyKey := c.Param("studyKey")
+
+	var req StudyTrackAccountUpdateReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		slog.Error("failed to bind request", slog.String("error", err.Error()))
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	slog.Info("updating study track account", slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject), slog.String("studyKey", studyKey), slog.Bool("trackAccount", req.TrackAccount))
+
+	err := h.studyDBConn.UpdateStudyTrackAccount(token.InstanceID, studyKey, req.TrackAccount)
+	if err != nil {
+		slog.Error("failed to update study track account", slog.String("error", err.Error()))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update study track account"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "study track account updated"})
 }
 
 func (h *HttpEndpoints) deleteStudy(c *gin.Context) {

--- a/services/participant-api/apihandlers/study-service.go
+++ b/services/participant-api/apihandlers/study-service.go
@@ -22,7 +22,6 @@ import (
 	surveyresponses "github.com/case-framework/case-backend/pkg/study/exporter/survey-responses"
 	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
 	studyutils "github.com/case-framework/case-backend/pkg/study/utils"
-	umUtils "github.com/case-framework/case-backend/pkg/user-management/utils"
 )
 
 const (
@@ -366,7 +365,15 @@ func (h *HttpEndpoints) enterStudy(c *gin.Context) {
 		return
 	}
 
-	if !h.checkProfileBelongsToUser(token.InstanceID, token.Subject, req.ProfileID) {
+	user, err := h.userDBConn.GetUser(token.InstanceID, token.Subject)
+	if err != nil {
+		slog.Error("error getting user", slog.String("error", err.Error()))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting user"})
+		return
+	}
+
+	profile, err := user.FindProfile(req.ProfileID)
+	if err != nil {
 		slog.Warn("profile not found", slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject), slog.String("profileID", req.ProfileID))
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "profile not found"})
 		return
@@ -374,14 +381,7 @@ func (h *HttpEndpoints) enterStudy(c *gin.Context) {
 
 	slog.Debug("entering study", slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject), slog.String("studyKey", studyKey))
 
-	user, err := h.userDBConn.GetUser(token.InstanceID, token.Subject)
-	if err != nil {
-		slog.Error("error getting user", slog.String("error", err.Error()))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting user"})
-		return
-	}
-	mainProfileID, _ := umUtils.GetMainAndOtherProfiles(user)
-	isMainProfile := mainProfileID == req.ProfileID
+	isMainProfile := profile.MainProfile
 
 	result, err := studyService.OnEnterStudy(token.InstanceID, studyKey, req.ProfileID, user.Account.AccountID, isMainProfile)
 	if err != nil {

--- a/services/participant-api/apihandlers/study-service.go
+++ b/services/participant-api/apihandlers/study-service.go
@@ -22,6 +22,7 @@ import (
 	surveyresponses "github.com/case-framework/case-backend/pkg/study/exporter/survey-responses"
 	studyTypes "github.com/case-framework/case-backend/pkg/study/types"
 	studyutils "github.com/case-framework/case-backend/pkg/study/utils"
+	umUtils "github.com/case-framework/case-backend/pkg/user-management/utils"
 )
 
 const (
@@ -373,7 +374,16 @@ func (h *HttpEndpoints) enterStudy(c *gin.Context) {
 
 	slog.Debug("entering study", slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject), slog.String("studyKey", studyKey))
 
-	result, err := studyService.OnEnterStudy(token.InstanceID, studyKey, req.ProfileID)
+	user, err := h.userDBConn.GetUser(token.InstanceID, token.Subject)
+	if err != nil {
+		slog.Error("error getting user", slog.String("error", err.Error()))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting user"})
+		return
+	}
+	mainProfileID, _ := umUtils.GetMainAndOtherProfiles(user)
+	isMainProfile := mainProfileID == req.ProfileID
+
+	result, err := studyService.OnEnterStudy(token.InstanceID, studyKey, req.ProfileID, user.Account.AccountID, isMainProfile)
 	if err != nil {
 		slog.Error("error entering study", slog.String("error", err.Error()))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "error entering study"})

--- a/services/participant-api/apihandlers/utils.go
+++ b/services/participant-api/apihandlers/utils.go
@@ -142,12 +142,8 @@ func (h *HttpEndpoints) checkProfileBelongsToUser(instanceID, userID, profileID 
 		return false
 	}
 
-	for _, profile := range user.Profiles {
-		if profile.ID.Hex() == profileID {
-			return true
-		}
-	}
-	return false
+	_, err = user.FindProfile(profileID)
+	return err == nil
 }
 
 func (h *HttpEndpoints) checkAllProfilesBelongsToUser(instanceID, userID string, profileIDs []string) bool {


### PR DESCRIPTION
This PR introduces a new feature to track account information for study participants. Enables studies to optionally track pseudonymized account IDs and main profile status for participants, with a migration job and management endpoints to control this feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Studies can opt in to account tracking to store participants' hashed account identifiers and primary-profile flags.
  * Management API endpoint to enable/disable account tracking per study.
  * Participant entry now includes account-context so tracking is applied for newly created participants.

* **Chores**
  * New migration job to backfill hashed account info for existing participants across configured instances; startup can run it when enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/case-framework/case-backend/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->