### PR TITLE
feat: enhance response export with account tracking

### DIFF
--- a/jobs/study-daily-data-export/response-exporter.go
+++ b/jobs/study-daily-data-export/response-exporter.go
@@ -63,6 +63,12 @@ func runResponseExportsForTask(rExpTask ResponseExportTask) {
 }
 
 func initResponseParser(instanceID string, studyKey string, surveyKey string, shortKeys bool, separator string) (parser *surveyresponses.ResponseParser, err error) {
+	study, err := studyDBService.GetStudy(instanceID, studyKey)
+	if err != nil {
+		slog.Error("failed to get study", slog.String("error", err.Error()))
+		return nil, err
+	}
+
 	surveyVersions, err := surveydefinition.PrepareSurveyInfosFromDB(
 		studyDBService,
 		instanceID,
@@ -91,10 +97,28 @@ func initResponseParser(instanceID string, studyKey string, surveyKey string, sh
 		slog.Error("failed to create response parser", slog.String("error", err.Error()))
 		return
 	}
+	if study.Configs.TrackAccount {
+		parser.EnableAccountTracking()
+	}
 	return
 }
 
+func getResponseAccountTrackingInfo(instanceID, studyKey, participantID string) surveyresponses.AccountTrackingInfo {
+	pState, err := studyDBService.GetParticipantByID(instanceID, studyKey, participantID)
+	if err != nil {
+		slog.Warn("failed to get participant account tracking info", slog.String("error", err.Error()), slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("participantID", participantID))
+		return surveyresponses.AccountTrackingInfo{}
+	}
+	return surveyresponses.AccountTrackingInfoFromParticipant(pState)
+}
+
 func generateExportForSurveyForTargetDate(instanceID string, studyKey string, surveyKey string, format string, targetDate time.Time, exportPath string, parser *surveyresponses.ResponseParser, createEmptyFile bool) {
+	study, err := studyDBService.GetStudy(instanceID, studyKey)
+	if err != nil {
+		slog.Error("failed to get study", slog.String("error", err.Error()))
+		return
+	}
+
 	fileName := responseFileName(targetDate, surveyKey, format)
 	responseFilePath := filepath.Join(exportPath, fileName)
 
@@ -138,6 +162,7 @@ func generateExportForSurveyForTargetDate(instanceID string, studyKey string, su
 		return
 	}
 
+	accountInfoCache := map[string]surveyresponses.AccountTrackingInfo{}
 	err = studyDBService.FindAndExecuteOnResponses(
 		context.Background(),
 		instanceID,
@@ -146,7 +171,17 @@ func generateExportForSurveyForTargetDate(instanceID string, studyKey string, su
 		bson.M{"arrivedAt": 1},
 		false,
 		func(dbService *studyDB.StudyDBService, r studyTypes.SurveyResponse, instanceID, studyKey string, args ...interface{}) error {
-			err := exporter.WriteResponse(&r)
+			trackingInfo := surveyresponses.AccountTrackingInfo{}
+			if study.Configs.TrackAccount {
+				var ok bool
+				trackingInfo, ok = accountInfoCache[r.ParticipantID]
+				if !ok {
+					trackingInfo = getResponseAccountTrackingInfo(instanceID, studyKey, r.ParticipantID)
+					accountInfoCache[r.ParticipantID] = trackingInfo
+				}
+			}
+
+			err := exporter.WriteResponse(&r, trackingInfo)
 			if err != nil {
 				return err
 			}

--- a/jobs/study-daily-data-export/response-exporter.go
+++ b/jobs/study-daily-data-export/response-exporter.go
@@ -36,7 +36,7 @@ func runResponseExportsForTask(rExpTask ResponseExportTask) {
 	}
 
 	for _, surveyKey := range rExpTask.SurveyKeys {
-		parser, err := initResponseParser(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ShortKeys, rExpTask.Separator)
+		parser, trackAccount, err := initResponseParser(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ShortKeys, rExpTask.Separator)
 		if err != nil {
 			continue
 		}
@@ -46,7 +46,7 @@ func runResponseExportsForTask(rExpTask ResponseExportTask) {
 				targetDate := time.Now().Add(
 					time.Duration(-(conf.ResponseExports.RetentionDays - i)) * time.Hour * 24,
 				)
-				generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser, rExpTask.CreateEmptyFile)
+				generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser, rExpTask.CreateEmptyFile, trackAccount)
 			}
 		}
 
@@ -54,19 +54,19 @@ func runResponseExportsForTask(rExpTask ResponseExportTask) {
 		targetDate := time.Now().Add(
 			time.Duration(-1 * time.Hour * 24),
 		)
-		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser, rExpTask.CreateEmptyFile)
+		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser, rExpTask.CreateEmptyFile, trackAccount)
 
 		// today
 		targetDate = time.Now()
-		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser, rExpTask.CreateEmptyFile)
+		generateExportForSurveyForTargetDate(rExpTask.InstanceID, rExpTask.StudyKey, surveyKey, rExpTask.ExportFormat, targetDate, exportFolderPathForTask, parser, rExpTask.CreateEmptyFile, trackAccount)
 	}
 }
 
-func initResponseParser(instanceID string, studyKey string, surveyKey string, shortKeys bool, separator string) (parser *surveyresponses.ResponseParser, err error) {
+func initResponseParser(instanceID string, studyKey string, surveyKey string, shortKeys bool, separator string) (*surveyresponses.ResponseParser, bool, error) {
 	study, err := studyDBService.GetStudy(instanceID, studyKey)
 	if err != nil {
 		slog.Error("failed to get study", slog.String("error", err.Error()))
-		return nil, err
+		return nil, false, err
 	}
 
 	surveyVersions, err := surveydefinition.PrepareSurveyInfosFromDB(
@@ -82,10 +82,10 @@ func initResponseParser(instanceID string, studyKey string, surveyKey string, sh
 	)
 	if err != nil {
 		slog.Error("failed to get survey versions", slog.String("error", err.Error()))
-		return
+		return nil, false, err
 	}
 	extraCols := conf.ResponseExports.ExportTasks[0].ExtraCtxCols
-	parser, err = surveyresponses.NewResponseParser(
+	parser, err := surveyresponses.NewResponseParser(
 		surveyKey,
 		surveyVersions,
 		shortKeys,
@@ -95,12 +95,13 @@ func initResponseParser(instanceID string, studyKey string, surveyKey string, sh
 	)
 	if err != nil {
 		slog.Error("failed to create response parser", slog.String("error", err.Error()))
-		return
+		return nil, false, err
 	}
-	if study.Configs.TrackAccount {
+	trackAccount := study.Configs.TrackAccount
+	if trackAccount {
 		parser.EnableAccountTracking()
 	}
-	return
+	return parser, trackAccount, nil
 }
 
 func getResponseAccountTrackingInfo(instanceID, studyKey, participantID string) surveyresponses.AccountTrackingInfo {
@@ -112,13 +113,7 @@ func getResponseAccountTrackingInfo(instanceID, studyKey, participantID string) 
 	return surveyresponses.AccountTrackingInfoFromParticipant(pState)
 }
 
-func generateExportForSurveyForTargetDate(instanceID string, studyKey string, surveyKey string, format string, targetDate time.Time, exportPath string, parser *surveyresponses.ResponseParser, createEmptyFile bool) {
-	study, err := studyDBService.GetStudy(instanceID, studyKey)
-	if err != nil {
-		slog.Error("failed to get study", slog.String("error", err.Error()))
-		return
-	}
-
+func generateExportForSurveyForTargetDate(instanceID string, studyKey string, surveyKey string, format string, targetDate time.Time, exportPath string, parser *surveyresponses.ResponseParser, createEmptyFile bool, trackAccount bool) {
 	fileName := responseFileName(targetDate, surveyKey, format)
 	responseFilePath := filepath.Join(exportPath, fileName)
 
@@ -172,7 +167,7 @@ func generateExportForSurveyForTargetDate(instanceID string, studyKey string, su
 		false,
 		func(dbService *studyDB.StudyDBService, r studyTypes.SurveyResponse, instanceID, studyKey string, args ...interface{}) error {
 			trackingInfo := surveyresponses.AccountTrackingInfo{}
-			if study.Configs.TrackAccount {
+			if trackAccount {
 				var ok bool
 				trackingInfo, ok = accountInfoCache[r.ParticipantID]
 				if !ok {

--- a/pkg/study/exporter/survey-responses/exporter.go
+++ b/pkg/study/exporter/survey-responses/exporter.go
@@ -72,6 +72,7 @@ func (re *ResponseExporter) init() error {
 
 func (re *ResponseExporter) WriteResponse(
 	rawResp *studytypes.SurveyResponse,
+	trackingInfo ...AccountTrackingInfo,
 ) error {
 
 	if re.parser == nil {
@@ -81,7 +82,7 @@ func (re *ResponseExporter) WriteResponse(
 		return fmt.Errorf("writer not initialized")
 	}
 
-	parsedResp, err := re.parser.ParseResponse(rawResp)
+	parsedResp, err := re.parser.ParseResponse(rawResp, trackingInfo...)
 	if err != nil {
 		return err
 	}

--- a/pkg/study/exporter/survey-responses/exporter_account_tracking_test.go
+++ b/pkg/study/exporter/survey-responses/exporter_account_tracking_test.go
@@ -1,0 +1,152 @@
+package surveyresponses
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	sd "github.com/case-framework/case-backend/pkg/study/exporter/survey-definition"
+	studytypes "github.com/case-framework/case-backend/pkg/study/types"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestResponseExporterAccountTracking(t *testing.T) {
+	mainProfile := true
+	trackingInfo := AccountTrackingInfo{
+		AccountID:   "pseudonymized-account-id",
+		MainProfile: &mainProfile,
+	}
+	response := studytypes.SurveyResponse{
+		ID:          primitive.NewObjectID(),
+		VersionID:   "v1",
+		ArrivedAt:   100,
+		SubmittedAt: 100,
+		Context: map[string]string{
+			accountIDColumn:   "context-account-id",
+			mainProfileColumn: "false",
+		},
+	}
+	extraContextColumns := []string{accountIDColumn, mainProfileColumn}
+	parser, err := NewResponseParser(
+		"survey",
+		[]sd.SurveyVersionPreview{{VersionID: "v1", Published: 1}},
+		false,
+		nil,
+		"-",
+		&extraContextColumns,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parser.EnableAccountTracking()
+
+	t.Run("csv", func(t *testing.T) {
+		var output bytes.Buffer
+		exporter, err := NewResponseExporter(parser, &output, "wide")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := exporter.WriteResponse(&response, trackingInfo); err != nil {
+			t.Fatal(err)
+		}
+		if err := exporter.Finish(); err != nil {
+			t.Fatal(err)
+		}
+
+		rows, err := csv.NewReader(strings.NewReader(output.String())).ReadAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rows[0][6] != accountIDColumn || rows[0][7] != mainProfileColumn {
+			t.Fatalf("tracking columns missing from CSV header: %v", rows[0])
+		}
+		for _, column := range []string{accountIDColumn, mainProfileColumn} {
+			count := 0
+			for _, header := range rows[0] {
+				if header == column {
+					count++
+				}
+			}
+			if count != 1 {
+				t.Fatalf("expected tracking column %q once, got header: %v", column, rows[0])
+			}
+		}
+		if rows[1][6] != trackingInfo.AccountID || rows[1][7] != "true" {
+			t.Fatalf("tracking values missing from CSV row: %v", rows[1])
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		var output bytes.Buffer
+		exporter, err := NewResponseExporter(parser, &output, "json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := exporter.WriteResponse(&response, trackingInfo); err != nil {
+			t.Fatal(err)
+		}
+		if err := exporter.Finish(); err != nil {
+			t.Fatal(err)
+		}
+
+		var result struct {
+			Responses []map[string]interface{} `json:"responses"`
+		}
+		if err := json.NewDecoder(strings.NewReader(output.String())).Decode(&result); err != nil {
+			t.Fatal(err)
+		}
+		if got := result.Responses[0][accountIDColumn]; got != trackingInfo.AccountID {
+			t.Fatalf("unexpected account ID: %v", got)
+		}
+		if got := result.Responses[0][mainProfileColumn]; got != true {
+			t.Fatalf("unexpected main profile value: %v", got)
+		}
+	})
+
+	t.Run("missing values are empty strings", func(t *testing.T) {
+		parsed, err := parser.ParseResponse(&response, AccountTrackingInfo{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := parser.ResponseToFlatObj(parsed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := result[accountIDColumn]; got != "" {
+			t.Fatalf("expected empty account ID, got %v", got)
+		}
+		if got := result[mainProfileColumn]; got != "" {
+			t.Fatalf("expected empty main profile, got %v", got)
+		}
+	})
+
+	t.Run("disabled omits tracking fields", func(t *testing.T) {
+		disabledParser, err := NewResponseParser(
+			"survey",
+			[]sd.SurveyVersionPreview{{VersionID: "v1", Published: 1}},
+			false,
+			nil,
+			"-",
+			&extraContextColumns,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		parsed, err := disabledParser.ParseResponse(&response, trackingInfo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := disabledParser.ResponseToFlatObj(parsed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, column := range []string{accountIDColumn, mainProfileColumn} {
+			if _, ok := result[column]; ok {
+				t.Fatalf("tracking field %q present while tracking is disabled", column)
+			}
+		}
+	})
+
+}

--- a/pkg/study/exporter/survey-responses/parser.go
+++ b/pkg/study/exporter/survey-responses/parser.go
@@ -15,6 +15,8 @@ var (
 		"engineVersion",
 		"session",
 	}
+	accountIDColumn   = "accountID"
+	mainProfileColumn = "mainProfile"
 )
 
 type ResponseParser struct {
@@ -24,6 +26,7 @@ type ResponseParser struct {
 	columns           ColumnNames
 	includeMeta       *IncludeMeta
 	questionOptionSep string
+	accountTracking   bool
 }
 
 func NewResponseParser(
@@ -59,10 +62,13 @@ func (rp *ResponseParser) initColumnNames(extraContextColumns *[]string) error {
 		"arrived",
 	}
 
-	ctxCols := defaultCtxColNames
+	ctxCols := append([]string{}, defaultCtxColNames...)
 	if extraContextColumns != nil {
 		ctxCols = append(ctxCols, *extraContextColumns...)
 	}
+	ctxCols = slices.DeleteFunc(ctxCols, func(column string) bool {
+		return column == accountIDColumn || column == mainProfileColumn
+	})
 
 	if rp.removeRootKey {
 		for versionInd, sv := range rp.surveyVersions {
@@ -87,8 +93,21 @@ func (rp *ResponseParser) initColumnNames(extraContextColumns *[]string) error {
 	return nil
 }
 
+// EnableAccountTracking adds the account tracking fields to all output
+// formats. The account ID value is the pseudonymized value from the
+// participant state.
+func (rp *ResponseParser) EnableAccountTracking() {
+	if rp.accountTracking {
+		return
+	}
+
+	rp.accountTracking = true
+	rp.columns.FixedColumns = append(rp.columns.FixedColumns, accountIDColumn, mainProfileColumn)
+}
+
 func (rp *ResponseParser) ParseResponse(
 	rawResp *studytypes.SurveyResponse,
+	trackingInfo ...AccountTrackingInfo,
 ) (ParsedResponse, error) {
 	parsedResponse := ParsedResponse{
 		ID:            rawResp.ID.Hex(),
@@ -105,6 +124,10 @@ func (rp *ResponseParser) ParseResponse(
 			Responded:   map[string][]int64{},
 			Position:    map[string]int32{},
 		},
+	}
+	if len(trackingInfo) > 0 {
+		parsedResponse.AccountID = trackingInfo[0].AccountID
+		parsedResponse.MainProfile = trackingInfo[0].MainProfile
 	}
 
 	currentVersion, err := findSurveyVersion(rawResp.VersionID, rawResp.ArrivedAt, rp.surveyVersions)
@@ -258,7 +281,7 @@ func (rp *ResponseParser) ResponseToFlatObj(
 func (rp ResponseParser) initWithFixedColumnsWithValues(
 	parsedResponse *ParsedResponse,
 ) map[string]interface{} {
-	return map[string]interface{}{
+	result := map[string]interface{}{
 		rp.columns.FixedColumns[0]: parsedResponse.ID,
 		rp.columns.FixedColumns[1]: parsedResponse.ParticipantID,
 		rp.columns.FixedColumns[2]: parsedResponse.Version,
@@ -266,6 +289,15 @@ func (rp ResponseParser) initWithFixedColumnsWithValues(
 		rp.columns.FixedColumns[4]: parsedResponse.SubmittedAt,
 		rp.columns.FixedColumns[5]: parsedResponse.ArrivedAt,
 	}
+	if rp.accountTracking {
+		result[accountIDColumn] = parsedResponse.AccountID
+		if parsedResponse.MainProfile != nil {
+			result[mainProfileColumn] = *parsedResponse.MainProfile
+		} else {
+			result[mainProfileColumn] = ""
+		}
+	}
+	return result
 }
 
 func (rp ResponseParser) addContextColumnsWithValues(

--- a/pkg/study/exporter/survey-responses/parser.go
+++ b/pkg/study/exporter/survey-responses/parser.go
@@ -9,12 +9,13 @@ import (
 	studytypes "github.com/case-framework/case-backend/pkg/study/types"
 )
 
-var (
-	defaultCtxColNames = []string{
-		"language",
-		"engineVersion",
-		"session",
-	}
+var defaultCtxColNames = []string{
+	"language",
+	"engineVersion",
+	"session",
+}
+
+const (
 	accountIDColumn   = "accountID"
 	mainProfileColumn = "mainProfile"
 )

--- a/pkg/study/exporter/survey-responses/types.go
+++ b/pkg/study/exporter/survey-responses/types.go
@@ -1,5 +1,7 @@
 package surveyresponses
 
+import studytypes "github.com/case-framework/case-backend/pkg/study/types"
+
 type ParsedResponse struct {
 	ID            string
 	ParticipantID string
@@ -7,9 +9,26 @@ type ParsedResponse struct {
 	SubmittedAt   int64
 	ArrivedAt     int64
 	Version       string
+	AccountID     string
+	MainProfile   *bool
 	Context       map[string]string // e.g. Language, or engine version
 	Responses     map[string]interface{}
 	Meta          ResponseMeta
+}
+
+// AccountTrackingInfo contains the pseudonymized account information stored
+// on a participant state. AccountID is intentionally the hashed account ID.
+type AccountTrackingInfo struct {
+	AccountID   string
+	MainProfile *bool
+}
+
+func AccountTrackingInfoFromParticipant(participant studytypes.Participant) AccountTrackingInfo {
+	info := AccountTrackingInfo{MainProfile: participant.IsMainProfile}
+	if participant.HashedAccountID != nil {
+		info.AccountID = *participant.HashedAccountID
+	}
+	return info
 }
 
 type ResponseMeta struct {

--- a/pkg/study/exporter/survey-responses/utils.go
+++ b/pkg/study/exporter/survey-responses/utils.go
@@ -19,6 +19,12 @@ func valueToStr(resultVal interface{}) string {
 	switch colValue := resultVal.(type) {
 	case string:
 		str = colValue
+	case bool:
+		str = fmt.Sprintf("%t", colValue)
+	case *bool:
+		if colValue != nil {
+			str = fmt.Sprintf("%t", *colValue)
+		}
 	case int:
 		str = fmt.Sprintf("%d", colValue)
 	case int32:

--- a/services/management-api/apihandlers/study-management.go
+++ b/services/management-api/apihandlers/study-management.go
@@ -2862,6 +2862,13 @@ func (h *HttpEndpoints) generateResponsesExport(c *gin.Context) {
 		return
 	}
 
+	study, err := h.studyDBConn.GetStudy(token.InstanceID, studyKey)
+	if err != nil {
+		slog.Error("failed to get study", slog.String("error", err.Error()))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get study"})
+		return
+	}
+
 	slog.Info("generating responses export", slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject), slog.String("studyKey", studyKey), slog.String("surveyKey", query.SurveyKey))
 
 	count, err := h.studyDBConn.GetResponsesCount(token.InstanceID, studyKey, query.PaginationInfos.Filter)
@@ -2870,7 +2877,6 @@ func (h *HttpEndpoints) generateResponsesExport(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get responses count"})
 		return
 	}
-
 	if count == 0 {
 		c.JSON(http.StatusOK, gin.H{
 			"error": "no responses to export",
@@ -2907,6 +2913,9 @@ func (h *HttpEndpoints) generateResponsesExport(c *gin.Context) {
 		slog.Error("failed to create response parser", slog.String("error", err.Error()))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create response parser"})
 		return
+	}
+	if study.Configs.TrackAccount {
+		respParser.EnableAccountTracking()
 	}
 
 	fileType := studyTypes.TASK_FILE_TYPE_CSV
@@ -2968,6 +2977,7 @@ func (h *HttpEndpoints) generateResponsesExport(c *gin.Context) {
 
 		ctx := context.Background()
 		counter := 0
+		accountInfoCache := map[string]surveyresponses.AccountTrackingInfo{}
 
 		err = h.studyDBConn.FindAndExecuteOnResponses(
 			ctx,
@@ -2980,7 +2990,17 @@ func (h *HttpEndpoints) generateResponsesExport(c *gin.Context) {
 				task := args[0].(*studyTypes.Task)
 				exporter := args[1].(*surveyresponses.ResponseExporter)
 
-				err := exporter.WriteResponse(&r)
+				trackingInfo := surveyresponses.AccountTrackingInfo{}
+				if study.Configs.TrackAccount {
+					var ok bool
+					trackingInfo, ok = accountInfoCache[r.ParticipantID]
+					if !ok {
+						trackingInfo = h.getResponseAccountTrackingInfo(instanceID, studyKey, r.ParticipantID)
+						accountInfoCache[r.ParticipantID] = trackingInfo
+					}
+				}
+
+				err := exporter.WriteResponse(&r, trackingInfo)
 				if err != nil {
 					return err
 				}
@@ -3953,6 +3973,15 @@ func (h *HttpEndpoints) getDailyExport(c *gin.Context) {
 	c.File(resultFilePath)
 }
 
+func (h *HttpEndpoints) getResponseAccountTrackingInfo(instanceID, studyKey, participantID string) surveyresponses.AccountTrackingInfo {
+	pState, err := h.studyDBConn.GetParticipantByID(instanceID, studyKey, participantID)
+	if err != nil {
+		slog.Warn("failed to get participant account tracking info", slog.String("error", err.Error()), slog.String("instanceID", instanceID), slog.String("studyKey", studyKey), slog.String("participantID", participantID))
+		return surveyresponses.AccountTrackingInfo{}
+	}
+	return surveyresponses.AccountTrackingInfoFromParticipant(pState)
+}
+
 func (h *HttpEndpoints) getStudyResponses(c *gin.Context) {
 	token := c.MustGet("validatedToken").(*jwthandling.ManagementUserClaims)
 
@@ -3969,6 +3998,13 @@ func (h *HttpEndpoints) getStudyResponses(c *gin.Context) {
 	if surveyKey == "" {
 		slog.Error("surveyKey is required", slog.String("instanceID", token.InstanceID), slog.String("userID", token.Subject), slog.String("studyKey", studyKey))
 		c.JSON(http.StatusBadRequest, gin.H{"error": "surveyKey is required"})
+		return
+	}
+
+	study, err := h.studyDBConn.GetStudy(token.InstanceID, studyKey)
+	if err != nil {
+		slog.Error("failed to get study", slog.String("error", err.Error()))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get study"})
 		return
 	}
 
@@ -4018,11 +4054,24 @@ func (h *HttpEndpoints) getStudyResponses(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create response parser"})
 		return
 	}
+	if study.Configs.TrackAccount {
+		respParser.EnableAccountTracking()
+	}
 
 	responses := make([]map[string]interface{}, len(rawResponses))
+	accountInfoCache := map[string]surveyresponses.AccountTrackingInfo{}
 
 	for i, rawResp := range rawResponses {
-		resp, err := respParser.ParseResponse(&rawResp)
+		trackingInfo := surveyresponses.AccountTrackingInfo{}
+		if study.Configs.TrackAccount {
+			var ok bool
+			trackingInfo, ok = accountInfoCache[rawResp.ParticipantID]
+			if !ok {
+				trackingInfo = h.getResponseAccountTrackingInfo(token.InstanceID, studyKey, rawResp.ParticipantID)
+				accountInfoCache[rawResp.ParticipantID] = trackingInfo
+			}
+		}
+		resp, err := respParser.ParseResponse(&rawResp, trackingInfo)
 		if err != nil {
 			slog.Error("failed to parse response", slog.String("error", err.Error()))
 			continue
@@ -4063,6 +4112,13 @@ func (h *HttpEndpoints) getStudyResponseById(c *gin.Context) {
 		return
 	}
 
+	study, err := h.studyDBConn.GetStudy(token.InstanceID, studyKey)
+	if err != nil {
+		slog.Error("failed to get study", slog.String("error", err.Error()))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get study"})
+		return
+	}
+
 	surveyVersions, err := surveydefinition.PrepareSurveyInfosFromDB(
 		h.studyDBConn,
 		token.InstanceID,
@@ -4093,8 +4149,15 @@ func (h *HttpEndpoints) getStudyResponseById(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create response parser"})
 		return
 	}
+	if study.Configs.TrackAccount {
+		respParser.EnableAccountTracking()
+	}
 
-	resp, err := respParser.ParseResponse(&rawResponse)
+	trackingInfo := surveyresponses.AccountTrackingInfo{}
+	if study.Configs.TrackAccount {
+		trackingInfo = h.getResponseAccountTrackingInfo(token.InstanceID, studyKey, rawResponse.ParticipantID)
+	}
+	resp, err := respParser.ParseResponse(&rawResponse, trackingInfo)
 	if err != nil {
 		slog.Error("failed to parse response", slog.String("error", err.Error()))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to parse response"})


### PR DESCRIPTION
Added functionality to track participant accounts in response exports. Introduced AccountTrackingInfo to store accountID and mainProfile attributes. Updated response parser and exporter to handle account tracking, including enabling tracking based on study configurations. Implemented tests to ensure correct CSV and JSON output for tracking fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional account tracking to study response exports and response retrieval.
  * When enabled, responses can include pseudonymized account IDs and main-profile indicators.
  * Account-tracking fields are supported in CSV and JSON output formats.
  * Tracking fields are omitted when the feature is disabled and remain blank when information is unavailable.

* **Bug Fixes**
  * Boolean tracking values now display correctly in exported response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->